### PR TITLE
Fix PyPI link

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,6 @@ dependencies = [
     "pytest>=6.2.0",
 ]
 [project.urls]
-Repository = "https://github.com/andfoy/pytest-run-parallel"
+Repository = "https://github.com/Quansight-labs/pytest-run-parallel"
 [project.entry-points.pytest11]
 run-parallel = "pytest_run_parallel.plugin"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,6 @@ dependencies = [
     "pytest>=6.2.0",
 ]
 [project.urls]
-Repository = "https://github.com/Quansight-labs/pytest-run-parallel"
+Repository = "https://github.com/Quansight-Labs/pytest-run-parallel"
 [project.entry-points.pytest11]
 run-parallel = "pytest_run_parallel.plugin"


### PR DESCRIPTION
Currently the "Repository" link in https://pypi.org/project/pytest-run-parallel/ links to https://github.com/andfoy/pytest-run-parallel, which doesn't exist anymore