### PR TITLE
Ensure that pytest.mark.skipif works

### DIFF
--- a/tests/test_run_parallel.py
+++ b/tests/test_run_parallel.py
@@ -489,3 +489,23 @@ def test_num_iterations_fixture(pytester):
             "*::test_should_yield_marker_threads PASSED*",
         ]
     )
+
+def test_skipif_marker_works(pytester):
+    # create a temporary pytest test module
+    pytester.makepyfile("""
+        import pytest
+
+        VAR = 1
+
+        @pytest.mark.skipif('VAR == 1', reason='VAR is 1')
+        def test_should_skip():
+            pass
+    """)
+
+    # run pytest with the following cmd args
+    result = pytester.runpytest("--parallel-threads=10", "-v")
+
+    # fnmatch_lines does an assertion internally
+    result.stdout.fnmatch_lines(
+        ["*::test_should_skip SKIPPED*",]
+    )


### PR DESCRIPTION
Fixes #13 

`pytest.mark.skipif` relies on the `__globals__` dictionary of the original test function. Given that `pytest-run-parallel` wraps such function from another scope, modules and variables present on the original test function scoped were dropped, preventing the decorator from working. The changes in this PR ensure that the variables defined on the original scoped are copied over the new one.