### PR TITLE
Add thread_unsafe marker as an alias for parallel_threads(1)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,9 +37,11 @@ Features
 * Two global CLI flags:
     * ``--parallel-threads`` to run a test suite in parallel
     * ``--iterations`` to run multiple times in each thread
-* Two corresponding markers:
+* Three corresponding markers:
     * ``pytest.mark.parallel_threads(n)`` to mark a single test to run in
       parallel in ``n`` threads
+    * ``pytest.mark.thread_unsafe`` to mark a single test to run in a single
+      thread. It is equivalent to using ``pytest.mark.parallel_threads(1)``
     * ``pytest.mark.iterations(n)`` to mark a single test to run ``n`` times
       in each thread
 * And the corresponding fixtures:

--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -43,6 +43,10 @@ def pytest_configure(config):
         "markers",
         "iterations(n): run the given test function `n` times in each thread",
     )
+    config.addinivalue_line(
+        "markers",
+        "thread_unsafe: mark the test function as single-threaded",
+    )
 
 
 def wrap_function_parallel(fn, n_workers, n_iterations):
@@ -105,6 +109,11 @@ def pytest_itemcollected(item):
     m = item.get_closest_marker("iterations")
     if m is not None:
         n_iterations = int(m.args[0])
+
+    m = item.get_closest_marker("thread_unsafe")
+    if m is not None:
+        n_workers = 1
+        item.add_marker(pytest.mark.parallel_threads(1))
 
     if n_workers > 1 or n_iterations > 1:
         original_globals = item.obj.__globals__

--- a/tests/test_run_parallel.py
+++ b/tests/test_run_parallel.py
@@ -512,3 +512,24 @@ def test_skipif_marker_works(pytester):
             "*::test_should_skip SKIPPED*",
         ]
     )
+
+
+def test_thread_unsafe_marker(pytester):
+    # create a temporary pytest test module
+    pytester.makepyfile("""
+        import pytest
+
+        @pytest.mark.thread_unsafe
+        def test_should_run_single(num_parallel_threads):
+            assert num_parallel_threads == 1
+    """)
+
+    # run pytest with the following cmd args
+    result = pytester.runpytest("--parallel-threads=10", "-v")
+
+    # fnmatch_lines does an assertion internally
+    result.stdout.fnmatch_lines(
+        [
+            "*::test_should_run_single PASSED*",
+        ]
+    )


### PR DESCRIPTION
See https://github.com/scipy/scipy/pull/21496#issuecomment-2472864469

This PR adds a new marker `thread_unsafe`, which works as an alias for `parallel_threads(1)`, this way it would be less verbose to mark single threaded tests.