### PR TITLE
Add a configuration  file option to extend the thread-unsafe fixture list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -132,13 +132,14 @@ Additionally, if a set of fixtures is known to be thread safe, tests can use
 them can be automatically marked as thread unsafe by declaring them under
 the `thread_unsafe_fixtures` option under pytest INI configuration file:
 
-```ini
-[pytest]
-thread_unsafe_fixtures =
-    fixture_1
-    fixture_2
-    ...
-```
+.. code-block:: ini
+
+    [pytest]
+    thread_unsafe_fixtures =
+        fixture_1
+        fixture_2
+        ...
+
 
 Usage
 -----

--- a/README.rst
+++ b/README.rst
@@ -128,6 +128,18 @@ build of Python.
 We suggest marking tests that are incompatible with this plugin's current design
 with ``@pytest.mark.thread_unsafe``.
 
+Additionally, if a set of fixtures is known to be thread safe, tests can use
+them can be automatically marked as thread unsafe by declaring them under
+the `thread_unsafe_fixtures` option under pytest INI configuration file:
+
+```ini
+[pytest]
+thread_unsafe_fixtures =
+    fixture_1
+    fixture_2
+    ...
+```
+
 Usage
 -----
 

--- a/README.rst
+++ b/README.rst
@@ -140,6 +140,16 @@ the `thread_unsafe_fixtures` option under pytest INI configuration file:
         fixture_2
         ...
 
+Or under the section `tool.pytest.ini_options` if using `pyproject.toml`:
+
+.. code-block:: toml
+
+    [tool.pytest.ini_options]
+    thread_unsafe_fixtures = [
+        'fixture_1',
+        'fixture_2',
+        ...
+    ]
 
 Usage
 -----

--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -29,9 +29,13 @@ def pytest_addoption(parser):
         type=int,
         help="Set the number of threads used to execute each test concurrently.",
     )
-    parser.addini("thread_unsafe_fixtures",
-                  'list of thread-unsafe fixture names that cause a test to '
-                  'be run sequentially', type='linelist', default=[])
+    parser.addini(
+        "thread_unsafe_fixtures",
+        "list of thread-unsafe fixture names that cause a test to "
+        "be run sequentially",
+        type="linelist",
+        default=[],
+    )
 
 
 def pytest_configure(config):
@@ -133,9 +137,9 @@ def pytest_itemcollected(item):
         n_workers = 1
         item.add_marker(pytest.mark.parallel_threads(1))
 
-    unsafe_fixtures = (
-        _thread_unsafe_fixtures |
-        set(item.config.getini('thread_unsafe_fixtures')))
+    unsafe_fixtures = _thread_unsafe_fixtures | set(
+        item.config.getini("thread_unsafe_fixtures")
+    )
 
     if any(fixture in fixtures for fixture in unsafe_fixtures):
         n_workers = 1

--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -29,6 +29,9 @@ def pytest_addoption(parser):
         type=int,
         help="Set the number of threads used to execute each test concurrently.",
     )
+    parser.addini("thread_unsafe_fixtures",
+                  'list of thread-unsafe fixture names that cause a test to '
+                  'be run sequentially', type='linelist', default=[])
 
 
 def pytest_configure(config):
@@ -130,7 +133,11 @@ def pytest_itemcollected(item):
         n_workers = 1
         item.add_marker(pytest.mark.parallel_threads(1))
 
-    if any(fixture in fixtures for fixture in _thread_unsafe_fixtures):
+    unsafe_fixtures = (
+        _thread_unsafe_fixtures |
+        set(item.config.getini('thread_unsafe_fixtures')))
+
+    if any(fixture in fixtures for fixture in unsafe_fixtures):
         n_workers = 1
         item.add_marker(pytest.mark.parallel_threads(1))
 

--- a/tests/test_run_parallel.py
+++ b/tests/test_run_parallel.py
@@ -757,11 +757,32 @@ def test_thread_unsafe_fixtures(pytester):
     pytester.makepyfile("""
         import pytest
 
+        @pytest.fixture
+        def my_unsafe_fixture():
+            pass
+
+        @pytest.fixture
+        def my_unsafe_fixture_2():
+            pass
+
         def test_capsys(capsys, num_parallel_threads):
             assert num_parallel_threads == 1
 
         def test_recwarn(recwarn, num_parallel_threads):
             assert num_parallel_threads == 1
+
+        def test_custom_fixture_skip(my_unsafe_fixture, num_parallel_threads):
+            assert num_parallel_threads == 1
+
+        def test_custom_fixture_skip_2(my_unsafe_fixture_2, num_parallel_threads):
+            assert num_parallel_threads == 1
+    """)
+
+    pytester.makeini("""
+    [pytest]
+    thread_unsafe_fixtures =
+        my_unsafe_fixture
+        my_unsafe_fixture_2
     """)
 
     # run pytest with the following cmd args
@@ -772,5 +793,6 @@ def test_thread_unsafe_fixtures(pytester):
         [
             "*::test_capsys PASSED*",
             "*::test_recwarn PASSED*",
+            "*::test_custom_fixture_skip PASSED*"
         ]
     )

--- a/tests/test_run_parallel.py
+++ b/tests/test_run_parallel.py
@@ -793,6 +793,6 @@ def test_thread_unsafe_fixtures(pytester):
         [
             "*::test_capsys PASSED*",
             "*::test_recwarn PASSED*",
-            "*::test_custom_fixture_skip PASSED*"
+            "*::test_custom_fixture_skip PASSED*",
         ]
     )

--- a/tests/test_run_parallel.py
+++ b/tests/test_run_parallel.py
@@ -794,5 +794,6 @@ def test_thread_unsafe_fixtures(pytester):
             "*::test_capsys PASSED*",
             "*::test_recwarn PASSED*",
             "*::test_custom_fixture_skip PASSED*",
+            "*::test_custom_fixture_skip_2 PASSED*",
         ]
     )


### PR DESCRIPTION
See https://github.com/Quansight-Labs/pytest-run-parallel/pull/33#discussion_r2016864565

This PR adds an `thread_unsafe_fixtures` INI configuration key, which allows for downstream projects to extend the current list of known thread-unsafe fixtures.

cc @ngoldbaum @rgommers  