### PR TITLE
fail more gracefully when a test item doesn't duck type

### DIFF
--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -1,6 +1,7 @@
 import functools
 import sys
 import threading
+import warnings
 
 import _pytest.outcomes
 import pytest
@@ -132,6 +133,12 @@ def pytest_itemcollected(item):
     if m is not None:
         n_workers = 1
         item.add_marker(pytest.mark.parallel_threads(1))
+
+    if not hasattr(item, "obj"):
+        warnings.warn("Encountered PyTest item that is incompatible "
+                      "with pytest-run-parallel, skipping pytest-run-parallel "
+                      "monkeypatching")
+        return
 
     if identify_warnings_handling(item.obj):
         n_workers = 1


### PR DESCRIPTION
If I run pytest on the pyyaml test suite with pytest-run-parallel installed, I get a warning at the end of the tests:

```
=============================== warnings summary ===============================
tests/legacy_tests/conftest.py:130
  /Users/goldbaum/Documents/pyyaml/tests/legacy_tests/conftest.py:130: UserWarning: libyaml extension is not available, skipping libyaml tests
    warnings.warn('libyaml extension is not available, skipping libyaml tests')

../pytest-run-parallel/src/pytest_run_parallel/plugin.py:138
  /Users/goldbaum/Documents/pytest-run-parallel/src/pytest_run_parallel/plugin.py:138: UserWarning: Encountered PyTest item that is incompatible with pytest-run-parallel, skipping pytest-run-parallel monkeypatching
    warnings.warn("Encountered PyTest item that is incompatible "

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================= 1283 passed, 2 warnings in 1.60s =======================
```