### PR TITLE
Implement a mechanism for registering and marking functions as thread-unsafe

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -151,10 +151,11 @@ Or under the section `tool.pytest.ini_options` if using `pyproject.toml`:
         ...
     ]
 
-Similarly, if a set of functions call are known to be thread unsafe and should
-cause a test to be marked as well, their fully-qualified names can be
-registered through the `thread_unsafe_functions` option in the INI file
-(or under `tool.pytest.ini_options` when using `pyproject.toml`):
+Similarly, if a function is known to be thread unsafe and should
+cause a test to be marked as thread-unsafe as well, the fully-qualified names 
+of thread-unsafe functions can be registered through the 
+`thread_unsafe_functions` option in the INI file (or under 
+`tool.pytest.ini_options` when using `pyproject.toml`):
 
 .. code-block:: ini
 
@@ -164,9 +165,10 @@ registered through the `thread_unsafe_functions` option in the INI file
         module.submodule2.func2
         ...
 
-Also, functions that declare the assignment `__thread_unsafe__ = True` that get
-called by a test and are up to two levels below in the call stack will
-automatically cause such test to be marked as thread unsafe.
+Also, if you define a `__thread_unsafe__` attribute on a function that is
+called by a test and is up to two levels below in the call stack, then 
+pytest-run-parallel will automatically detect that a thread-unsafe function
+is being used and will mark the test as thread-unsafe.
 
 Usage
 -----

--- a/README.rst
+++ b/README.rst
@@ -152,10 +152,9 @@ Or under the section `tool.pytest.ini_options` if using `pyproject.toml`:
     ]
 
 Similarly, if a function is known to be thread unsafe and should
-cause a test to be marked as thread-unsafe as well, the fully-qualified names
-of thread-unsafe functions can be registered through the
-`thread_unsafe_functions` option in the INI file (or under
-`tool.pytest.ini_options` when using `pyproject.toml`):
+cause a test to be marked as thread-unsafe as well, its fully-qualified name
+can be registered through the `thread_unsafe_functions` option in the
+INI file (or under `tool.pytest.ini_options` when using `pyproject.toml`):
 
 .. code-block:: ini
 
@@ -165,7 +164,7 @@ of thread-unsafe functions can be registered through the
         module.submodule2.func2
         ...
 
-Also, if you define a `__thread_unsafe__` attribute on a function that is
+Also, if you define a `__thread_safe__ = False` attribute on a function that is
 called by a test and is up to two levels below in the call stack, then
 pytest-run-parallel will automatically detect that a thread-unsafe function
 is being used and will mark the test as thread-unsafe.

--- a/README.rst
+++ b/README.rst
@@ -152,9 +152,9 @@ Or under the section `tool.pytest.ini_options` if using `pyproject.toml`:
     ]
 
 Similarly, if a function is known to be thread unsafe and should
-cause a test to be marked as thread-unsafe as well, the fully-qualified names 
-of thread-unsafe functions can be registered through the 
-`thread_unsafe_functions` option in the INI file (or under 
+cause a test to be marked as thread-unsafe as well, the fully-qualified names
+of thread-unsafe functions can be registered through the
+`thread_unsafe_functions` option in the INI file (or under
 `tool.pytest.ini_options` when using `pyproject.toml`):
 
 .. code-block:: ini
@@ -166,7 +166,7 @@ of thread-unsafe functions can be registered through the
         ...
 
 Also, if you define a `__thread_unsafe__` attribute on a function that is
-called by a test and is up to two levels below in the call stack, then 
+called by a test and is up to two levels below in the call stack, then
 pytest-run-parallel will automatically detect that a thread-unsafe function
 is being used and will mark the test as thread-unsafe.
 

--- a/README.rst
+++ b/README.rst
@@ -151,6 +151,23 @@ Or under the section `tool.pytest.ini_options` if using `pyproject.toml`:
         ...
     ]
 
+Similarly, if a set of functions call are known to be thread unsafe and should
+cause a test to be marked as well, their fully-qualified names can be
+registered through the `thread_unsafe_functions` option in the INI file
+(or under `tool.pytest.ini_options` when using `pyproject.toml`):
+
+.. code-block:: ini
+
+    [pytest]
+    thread_unsafe_functions =
+        module.submodule.func1
+        module.submodule2.func2
+        ...
+
+Also, functions that declare the assignment `__thread_unsafe__ = True` that get
+called by a test and are up to two levels below in the call stack will
+automatically cause such test to be marked as thread unsafe.
+
 Usage
 -----
 

--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -159,8 +159,9 @@ def pytest_itemcollected(item):
         return
 
     skipped_functions = [
-        x.split('.') for x in item.config.getini("thread_unsafe_functions")]
-    skipped_functions = {('.'.join(x[:-1]), x[-1]) for x in skipped_functions}
+        x.split(".") for x in item.config.getini("thread_unsafe_functions")
+    ]
+    skipped_functions = {(".".join(x[:-1]), x[-1]) for x in skipped_functions}
 
     if identify_warnings_handling(item.obj, skipped_functions):
         n_workers = 1

--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -37,6 +37,13 @@ def pytest_addoption(parser):
         type="linelist",
         default=[],
     )
+    parser.addini(
+        "thread_unsafe_functions",
+        "list of thread-unsafe fully-qualified named functions that cause "
+        "a test to be run sequentially",
+        type="linelist",
+        default=[],
+    )
 
 
 def pytest_configure(config):
@@ -151,7 +158,11 @@ def pytest_itemcollected(item):
         )
         return
 
-    if identify_warnings_handling(item.obj):
+    skipped_functions = [
+        x.split('.') for x in item.config.getini("thread_unsafe_functions")]
+    skipped_functions = {('.'.join(x[:-1]), x[-1]) for x in skipped_functions}
+
+    if identify_warnings_handling(item.obj, skipped_functions):
         n_workers = 1
         item.add_marker(pytest.mark.parallel_threads(1))
 

--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -40,7 +40,7 @@ def pytest_addoption(parser):
     parser.addini(
         "thread_unsafe_functions",
         "list of thread-unsafe fully-qualified named functions that cause "
-        "a test to be run sequentially",
+        "a test to run on one thread",
         type="linelist",
         default=[],
     )

--- a/src/pytest_run_parallel/utils.py
+++ b/src/pytest_run_parallel/utils.py
@@ -30,7 +30,7 @@ class WarningNodeVisitor(ast.NodeVisitor):
         self.level = level
         self.modules_aliases = {}
         self.func_aliases = {}
-        for var_name in fn.__globals__:
+        for var_name in getattr(fn, '__globals__', {}):
             value = fn.__globals__[var_name]
             if inspect.ismodule(value) and value.__name__ in modules:
                 self.modules_aliases[var_name] = value.__name__
@@ -63,15 +63,16 @@ class WarningNodeVisitor(ast.NodeVisitor):
                                 child_fn, self.skip_set, self.level + 1
                             )
         elif isinstance(node.func, ast.Name):
+            recurse = True
             if node.func.id in self.func_aliases:
                 if self.func_aliases[node.func.id] in self.blacklist:
                     self.catches_warns = True
-                elif self.level < 2:
-                    if node.func.id in self.fn.__globals__:
-                        child_fn = self.fn.__globals__[node.func.id]
-                        self.catches_warns = identify_warnings_handling(
-                            child_fn, self.skip_set, self.level + 1
-                        )
+                    recurse = False
+            if recurse and self.level < 2:
+                if node.func.id in self.fn.__globals__:
+                    child_fn = self.fn.__globals__[node.func.id]
+                    self.catches_warns = identify_warnings_handling(
+                        child_fn, self.skip_set, self.level + 1)
 
     def visit_Assign(self, node):
         if self.catches_warns:
@@ -80,7 +81,7 @@ class WarningNodeVisitor(ast.NodeVisitor):
         if len(node.targets) == 1:
             name_node = node.targets[0]
             value_node = node.value
-            if name_node.id == "__thread_unsafe__":
+            if getattr(name_node, 'id', None) == '__thread_unsafe__':
                 self.catches_warns = value_node.value
 
 

--- a/src/pytest_run_parallel/utils.py
+++ b/src/pytest_run_parallel/utils.py
@@ -55,7 +55,7 @@ class WarningNodeVisitor(ast.NodeVisitor):
                 if (real_mod, node.func.attr) in self.blacklist:
                     self.catches_warns = True
                 elif self.level < 2:
-                    if node.func.value.id in self.fn.__globals__:
+                    if node.func.value.id in getattr(self.fn, '__globals__', {}):
                         mod = self.fn.__globals__[node.func.value.id]
                         child_fn = getattr(mod, node.func.attr, None)
                         if child_fn is not None:

--- a/src/pytest_run_parallel/utils.py
+++ b/src/pytest_run_parallel/utils.py
@@ -55,7 +55,7 @@ class WarningNodeVisitor(ast.NodeVisitor):
                 if (real_mod, node.func.attr) in self.blacklist:
                     self.catches_warns = True
                 elif self.level < 2:
-                    if node.func.value.id in getattr(self.fn, '__globals__', {}):
+                    if node.func.value.id in getattr(self.fn, "__globals__", {}):
                         mod = self.fn.__globals__[node.func.value.id]
                         child_fn = getattr(mod, node.func.attr, None)
                         if child_fn is not None:

--- a/src/pytest_run_parallel/utils.py
+++ b/src/pytest_run_parallel/utils.py
@@ -69,7 +69,7 @@ class WarningNodeVisitor(ast.NodeVisitor):
                     self.catches_warns = True
                     recurse = False
             if recurse and self.level < 2:
-                if node.func.id in getattr(self.fn, '__globals__', {}):
+                if node.func.id in getattr(self.fn, "__globals__", {}):
                     child_fn = self.fn.__globals__[node.func.id]
                     self.catches_warns = identify_warnings_handling(
                         child_fn, self.skip_set, self.level + 1

--- a/src/pytest_run_parallel/utils.py
+++ b/src/pytest_run_parallel/utils.py
@@ -60,7 +60,8 @@ class WarningNodeVisitor(ast.NodeVisitor):
                         child_fn = getattr(mod, node.func.attr, None)
                         if child_fn is not None:
                             self.catches_warns = identify_warnings_handling(
-                                child_fn, self.skip_set, self.level + 1)
+                                child_fn, self.skip_set, self.level + 1
+                            )
         elif isinstance(node.func, ast.Name):
             if node.func.id in self.func_aliases:
                 if self.func_aliases[node.func.id] in self.blacklist:
@@ -69,7 +70,8 @@ class WarningNodeVisitor(ast.NodeVisitor):
                     if node.func.id in self.fn.__globals__:
                         child_fn = self.fn.__globals__[node.func.id]
                         self.catches_warns = identify_warnings_handling(
-                            child_fn, self.skip_set, self.level + 1)
+                            child_fn, self.skip_set, self.level + 1
+                        )
 
     def visit_Assign(self, node):
         if self.catches_warns:
@@ -78,7 +80,7 @@ class WarningNodeVisitor(ast.NodeVisitor):
         if len(node.targets) == 1:
             name_node = node.targets[0]
             value_node = node.value
-            if name_node.id == '__thread_unsafe__':
+            if name_node.id == "__thread_unsafe__":
                 self.catches_warns = value_node.value
 
 

--- a/src/pytest_run_parallel/utils.py
+++ b/src/pytest_run_parallel/utils.py
@@ -82,8 +82,8 @@ class WarningNodeVisitor(ast.NodeVisitor):
         if len(node.targets) == 1:
             name_node = node.targets[0]
             value_node = node.value
-            if getattr(name_node, "id", None) == "__thread_unsafe__":
-                self.catches_warns = value_node.value
+            if getattr(name_node, "id", None) == "__thread_safe__":
+                self.catches_warns = not bool(value_node.value)
 
 
 def identify_warnings_handling(fn, skip_set, level=0):

--- a/src/pytest_run_parallel/utils.py
+++ b/src/pytest_run_parallel/utils.py
@@ -69,7 +69,7 @@ class WarningNodeVisitor(ast.NodeVisitor):
                     self.catches_warns = True
                     recurse = False
             if recurse and self.level < 2:
-                if node.func.id in self.fn.__globals__:
+                if node.func.id in getattr(self.fn, '__globals__', {}):
                     child_fn = self.fn.__globals__[node.func.id]
                     self.catches_warns = identify_warnings_handling(
                         child_fn, self.skip_set, self.level + 1

--- a/src/pytest_run_parallel/utils.py
+++ b/src/pytest_run_parallel/utils.py
@@ -30,7 +30,7 @@ class WarningNodeVisitor(ast.NodeVisitor):
         self.level = level
         self.modules_aliases = {}
         self.func_aliases = {}
-        for var_name in getattr(fn, '__globals__', {}):
+        for var_name in getattr(fn, "__globals__", {}):
             value = fn.__globals__[var_name]
             if inspect.ismodule(value) and value.__name__ in modules:
                 self.modules_aliases[var_name] = value.__name__
@@ -72,7 +72,8 @@ class WarningNodeVisitor(ast.NodeVisitor):
                 if node.func.id in self.fn.__globals__:
                     child_fn = self.fn.__globals__[node.func.id]
                     self.catches_warns = identify_warnings_handling(
-                        child_fn, self.skip_set, self.level + 1)
+                        child_fn, self.skip_set, self.level + 1
+                    )
 
     def visit_Assign(self, node):
         if self.catches_warns:
@@ -81,7 +82,7 @@ class WarningNodeVisitor(ast.NodeVisitor):
         if len(node.targets) == 1:
             name_node = node.targets[0]
             value_node = node.value
-            if getattr(name_node, 'id', None) == '__thread_unsafe__':
+            if getattr(name_node, "id", None) == "__thread_unsafe__":
                 self.catches_warns = value_node.value
 
 

--- a/tests/test_run_parallel.py
+++ b/tests/test_run_parallel.py
@@ -938,6 +938,6 @@ def test_thread_unsafe_function_attr(pytester):
             "*::test_should_be_marked_1 PASSED*",
             "*::test_should_not_be_marked PASSED*",
             "*::test_should_be_marked_2 PASSED*",
-            "*::test_should_be_marked_3 PASSED*"
+            "*::test_should_be_marked_3 PASSED*",
         ]
     )

--- a/tests/test_run_parallel.py
+++ b/tests/test_run_parallel.py
@@ -879,10 +879,10 @@ def test_thread_unsafe_function_attr(pytester):
     pytester.makepyfile(
         mod_1="""
         def to_skip():
-            __thread_unsafe__ = True
+            __thread_safe__ = False
 
         def not_to_skip():
-            __thread_unsafe__ = False
+            __thread_safe__ = True
     """
     )
 
@@ -904,6 +904,7 @@ def test_thread_unsafe_function_attr(pytester):
 
     pytester.makepyfile("""
         import mod_2
+        from mod_2 import some_fn_calls_skip
 
         def test_should_be_marked_1(num_parallel_threads):
             mod_2.some_fn_calls_skip()
@@ -915,6 +916,10 @@ def test_thread_unsafe_function_attr(pytester):
 
         def test_should_be_marked_2(num_parallel_threads):
             mod_2.marked_for_skip()
+            assert num_parallel_threads == 1
+
+        def test_should_be_marked_3(num_parallel_threads):
+            some_fn_calls_skip()
             assert num_parallel_threads == 1
     """)
 
@@ -933,5 +938,6 @@ def test_thread_unsafe_function_attr(pytester):
             "*::test_should_be_marked_1 PASSED*",
             "*::test_should_not_be_marked PASSED*",
             "*::test_should_be_marked_2 PASSED*",
+            "*::test_should_be_marked_3 PASSED*"
         ]
     )

--- a/tests/test_run_parallel.py
+++ b/tests/test_run_parallel.py
@@ -876,15 +876,18 @@ def test_known_incompatible_test_item_doesnt_warn(pytester):
     assert "warnings" not in result.parseoutcomes().keys()
 
 def test_thread_unsafe_function_attr(pytester):
-    pytester.makepyfile(mod_1="""
+    pytester.makepyfile(
+        mod_1="""
         def to_skip():
             __thread_unsafe__ = True
 
         def not_to_skip():
             __thread_unsafe__ = False
-    """)
+    """
+    )
 
-    pytester.makepyfile(mod_2="""
+    pytester.makepyfile(
+        mod_2="""
         import mod_1
         from mod_1 import not_to_skip
 
@@ -896,7 +899,8 @@ def test_thread_unsafe_function_attr(pytester):
 
         def marked_for_skip():
             pass
-    """)
+    """
+    )
 
     pytester.makepyfile("""
         import mod_2

--- a/tests/test_run_parallel.py
+++ b/tests/test_run_parallel.py
@@ -874,3 +874,60 @@ def test_known_incompatible_test_item_doesnt_warn(pytester):
         "with no 'obj'*"
     )
     assert "warnings" not in result.parseoutcomes().keys()
+
+def test_thread_unsafe_function_attr(pytester):
+    pytester.makepyfile(mod_1="""
+        def to_skip():
+            __thread_unsafe__ = True
+
+        def not_to_skip():
+            __thread_unsafe__ = False
+    """)
+
+    pytester.makepyfile(mod_2="""
+        import mod_1
+        from mod_1 import not_to_skip
+
+        def some_fn_calls_skip():
+            mod_1.to_skip()
+
+        def some_fn_should_not_skip():
+            not_to_skip()
+
+        def marked_for_skip():
+            pass
+    """)
+
+    pytester.makepyfile("""
+        import mod_2
+
+        def test_should_be_marked_1(num_parallel_threads):
+            mod_2.some_fn_calls_skip()
+            assert num_parallel_threads == 1
+
+        def test_should_not_be_marked(num_parallel_threads):
+            mod_2.some_fn_should_not_skip()
+            assert num_parallel_threads == 10
+
+        def test_should_be_marked_2(num_parallel_threads):
+            mod_2.marked_for_skip()
+            assert num_parallel_threads == 1
+    """)
+
+    pytester.makeini("""
+    [pytest]
+    thread_unsafe_functions =
+        mod_2.marked_for_skip
+    """)
+
+    # run pytest with the following cmd args
+    result = pytester.runpytest("--parallel-threads=10", "-v")
+
+    # fnmatch_lines does an assertion internally
+    result.stdout.fnmatch_lines(
+        [
+            "*::test_should_be_marked_1 PASSED*",
+            "*::test_should_not_be_marked PASSED*",
+            "*::test_should_be_marked_2 PASSED*",
+        ]
+    )

--- a/tests/test_run_parallel.py
+++ b/tests/test_run_parallel.py
@@ -875,6 +875,7 @@ def test_known_incompatible_test_item_doesnt_warn(pytester):
     )
     assert "warnings" not in result.parseoutcomes().keys()
 
+
 def test_thread_unsafe_function_attr(pytester):
     pytester.makepyfile(
         mod_1="""


### PR DESCRIPTION
Fixes #35 

This PR adds two new mechanisms to register custom functions whose invocation should cause a test to be executed in a single thread. 

The first works by setting the variable `__thread_unsafe__` to `True`, while the second one relies on static values provided via the INI configuration file. On both cases, the functions will be checked up to two levels in the call-stack (derived from the AST).

cc @rgommers 