### PR TITLE
Make sure sdist includes all files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,11 @@
+include tests/conftest.py
+exclude pytest_run_parallel.egg-info
+recursive-exclude * *.egg-info
+recursive-include docs *.bat
+recursive-include docs *.rst
+recursive-include docs Makefile
+include *.lock
+include *.md
+include *.toml
+include *.yaml
+recursive-include docs *.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,15 +69,22 @@ select = ["E4", "E7", "E9", "F", "I"]
 env_list = ["py38", "py39", "py310", "py311", "py312", "py313", "py313t", "pypy3", "ruff"]
 
 [tool.tox.env_run_base]
-deps = ["pytest>=6.2.0", "pytest-cov", "pytest-order"]
-commands = [[
+deps = ["pytest>=6.2.0", "pytest-cov", "pytest-order", "check-manifest"]
+commands = [
+    [
     "pytest",
     "-v",
     "--cov-report", "lcov",
     "--cov", "src/pytest_run_parallel",
     "--cov", "tests",
     "{posargs:tests}"
-]]
+    ],
+    [
+    "check-manifest",
+    "-u",
+    "-v",
+    ]
+]
 
 [tool.tox.env.ruff]
 skip_install = true


### PR DESCRIPTION
Fixes #38.

Also adds `check-manifest` to the tox tests.