### PR TITLE
Include conftest.py in sdist and fix license-related build warnings

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include tests/conftest.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ authors = [
 maintainers = [
     { name = "Quansight Labs", email = "emargffoy@quansight.com" },
 ]
-license = {file = "LICENSE"}
+license = "MIT"
+license-files = ["LICENSE"]
 classifiers = [
     "Framework :: Pytest",
     "Development Status :: 4 - Beta",
@@ -37,7 +38,6 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
-    "License :: OSI Approved :: MIT License",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -294,7 +294,7 @@ wheels = [
 
 [[package]]
 name = "pytest-run-parallel"
-version = "0.3.1.dev0"
+version = "0.3.2.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "pytest" },


### PR DESCRIPTION
- Include `conftest.py` in sdist to close #38
- Stop using the now-deprecated license object in `pyproject.toml` and move to using `license` and `license-files`.