### PR TITLE
Highlight which tests are being run in parallel

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -258,7 +258,25 @@ produced by all threads during an specific execution step are the same:
 
 Tracing
 ---------
-In order to list the tests that were listed as thread-unsafe and were not executed
+
+If you run pytest with verbose output (e.g. by passing ``-v`` in your pytest
+invocation), you will see that tests are annotated to either "PASS" or
+"PARALLEL PASS". A "PASS" indicates the test was run on a single thread, whereas
+"PARALLEL PASS" indicates the test passed and was run in a thread pool. If a
+test was not run in a thread pool because pytest-run-parallel detected use of
+thread-unsafe functionality, the reason will be printed as well.
+
+If you are running pytest in the default configuration without ``-v``, then
+tests that pass in a thread pool will be annotated with a slightly different dot
+character, allowing you to visually pick out when tests are not run in parallel.
+
+For example in the output for this file:
+
+    tests/test_kx.py ·....·
+
+Only the first and last tests are run in parallel.
+
+In order to list the tests that were marked as thread-unsafe and were not executed
 in parallel, you can set the ``PYTEST_RUN_PARALLEL_VERBOSE`` environment variable
 to 1.
 

--- a/README.rst
+++ b/README.rst
@@ -126,7 +126,7 @@ more detail about using pytest in a multithreaded context on the free-threaded
 build of Python.
 
 We suggest marking tests that are incompatible with this plugin's current design
-with ``@pytest.mark.thread_unsafe``.
+with ``@pytest.mark.thread_unsafe`` or ``@pytest.mark.thread_unsafe(reason="...")``.
 
 The following functions and modules are known to be thread-unsafe and
 pytest-run-parallel will automatically not run tests using them in parallel:
@@ -255,6 +255,12 @@ produced by all threads during an specific execution step are the same:
         c = None
         # Check that the values for a, b, c are the same across tests
         thread_comp(a=a, b=b, c=c)
+
+Tracing
+---------
+In order to list the tests that were listed as thread-unsafe and were not executed
+in parallel, you can set the ``PYTEST_RUN_PARALLEL_VERBOSE`` environment variable
+to 1.
 
 Contributing
 ------------

--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -177,7 +177,7 @@ def pytest_itemcollected(item):
 
     if n_workers > 1 or n_iterations > 1:
         item.add_marker(pytest.mark.parallel_threads(n_workers))
-        item.user_properties.append(('n_threads', n_workers))
+        item.user_properties.append(("n_threads", n_workers))
         original_globals = item.obj.__globals__
         item.obj = wrap_function_parallel(item.obj, n_workers, n_iterations)
         for name in original_globals:
@@ -199,12 +199,12 @@ def pytest_report_collectionfinish(config, start_path, startdir, items):
 @pytest.hookimpl(tryfirst=True)
 def pytest_report_teststatus(report, config):
     props = dict(report.user_properties)
-    if 'n_threads' in props and props['n_threads'] > 1:
-        if report.outcome == 'passed':
+    if "n_threads" in props and props["n_threads"] > 1:
+        if report.outcome == "passed":
             return "passed", "·", "PARALLEL PASSED"
-        if report.outcome == 'skipped':
+        if report.outcome == "skipped":
             return "skipped", "S", "PARALLEL SKIPPED"
-        if report.outcome == 'failed':
+        if report.outcome == "failed":
             return "error", "e", "PARALLEL FAILED"
 
 

--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -187,11 +187,11 @@ def pytest_itemcollected(item):
 
     if n_workers > 1 and any(fixture in fixtures for fixture in unsafe_fixtures):
         n_workers = 1
-        used_unsafe_fixtures = unsafe_fixtures | set(fixtures)
+        used_unsafe_fixtures = unsafe_fixtures & set(fixtures)
         item.user_properties.append(
             (
                 "thread_unsafe_reason",
-                f"uses thread-unsafe fixture(s) {used_unsafe_fixtures}",
+                f"uses thread-unsafe fixture(s): {used_unsafe_fixtures}",
             )
         )
         item.add_marker(pytest.mark.parallel_threads(1))

--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -1,6 +1,6 @@
 import functools
-import sys
 import os
+import sys
 import threading
 import warnings
 
@@ -140,9 +140,9 @@ def pytest_itemcollected(item):
     m = item.get_closest_marker("thread_unsafe")
     if m is not None:
         n_workers = 1
-        reason = m.kwargs.get('reason', None)
+        reason = m.kwargs.get("reason", None)
         if reason is not None:
-            item.user_properties.append(('thread_unsafe_reason', reason))
+            item.user_properties.append(("thread_unsafe_reason", reason))
         item.add_marker(pytest.mark.parallel_threads(1))
 
     if not hasattr(item, "obj"):
@@ -203,7 +203,7 @@ def pytest_report_collectionfinish(config, start_path, startdir, items):
 @pytest.hookimpl(tryfirst=True, wrapper=True)
 def pytest_report_teststatus(report, config):
     outcome = yield
-    if getattr(report, 'when', None) != 'call':
+    if getattr(report, "when", None) != "call":
         return outcome
 
     props = dict(report.user_properties)
@@ -212,39 +212,48 @@ def pytest_report_teststatus(report, config):
             return "passed", "·", "PARALLEL PASSED"
         if report.outcome == "failed":
             return "error", "e", "PARALLEL FAILED"
-    elif 'thread_unsafe_reason' in props:
-        if report.outcome == 'passed':
-            return "passed", ".", f"PASSED ([thread-unsafe]: {props['thread_unsafe_reason']})"
-        if report.outcome == 'failed':
-            return "passed", "x", f"FAILED ([thread-unsafe]: {props['thread_unsafe_reason']})"
+    elif "thread_unsafe_reason" in props:
+        if report.outcome == "passed":
+            return (
+                "passed",
+                ".",
+                f"PASSED ([thread-unsafe]: {props['thread_unsafe_reason']})",
+            )
+        if report.outcome == "failed":
+            return (
+                "passed",
+                "x",
+                f"FAILED ([thread-unsafe]: {props['thread_unsafe_reason']})",
+            )
     return outcome
 
 
 @pytest.hookimpl(trylast=True)
 def pytest_terminal_summary(terminalreporter, exitstatus, config):
-    verbose_tests = bool(int(os.environ.get(
-        'PYTEST_RUN_PARALLEL_VERBOSE', '0')))
+    verbose_tests = bool(int(os.environ.get("PYTEST_RUN_PARALLEL_VERBOSE", "0")))
 
-    terminalreporter.write_sep("*", 'List of tests *not* run in parallel')
+    terminalreporter.write_sep("*", "List of tests *not* run in parallel")
 
     num_serial = 0
     stats = terminalreporter.stats
     for stat_category in stats:
         reports = stats[stat_category]
         for report in reports:
-            if getattr(report, 'when', None) == 'call':
+            if getattr(report, "when", None) == "call":
                 report_props = dict(report.user_properties)
-                if 'n_threads' not in report_props:
+                if "n_threads" not in report_props:
                     if verbose_tests:
                         terminalreporter.line(report.nodeid)
                     num_serial += 1
 
     if not verbose_tests:
-        terminalreporter.line(f"{num_serial} tests were not run in parallel "
-                              "because of use of thread-unsafe functionality, "
-                              "to list the tests that were skipped, re-run "
-                              "while setting PYTEST_RUN_PARALLEL_VERBOSE=1 "
-                              "in your shell environment")
+        terminalreporter.line(
+            f"{num_serial} tests were not run in parallel "
+            "because of use of thread-unsafe functionality, "
+            "to list the tests that were skipped, re-run "
+            "while setting PYTEST_RUN_PARALLEL_VERBOSE=1 "
+            "in your shell environment"
+        )
 
 
 @pytest.fixture

--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -169,6 +169,8 @@ def pytest_itemcollected(item):
 
     if identify_thread_unsafe_nodes(item.obj, skipped_functions):
         n_workers = 1
+        item.user_properties.append(
+            ('thread_unsafe_reason', 'calls thread-unsafe function'))
         item.add_marker(pytest.mark.parallel_threads(1))
 
     unsafe_fixtures = _thread_unsafe_fixtures | set(
@@ -177,6 +179,8 @@ def pytest_itemcollected(item):
 
     if any(fixture in fixtures for fixture in unsafe_fixtures):
         n_workers = 1
+        item.user_properties.append(
+            ('thread_unsafe_reason', 'uses thread-unsafe fixture'))
         item.add_marker(pytest.mark.parallel_threads(1))
 
     if n_workers > 1 or n_iterations > 1:

--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -144,6 +144,9 @@ def pytest_itemcollected(item):
         reason = m.kwargs.get("reason", None)
         if reason is not None:
             item.user_properties.append(("thread_unsafe_reason", reason))
+        else:
+            item.user_properties.append(("thread_unsafe_reason",
+                                         "uses thread_unsafe marker"))
         item.add_marker(pytest.mark.parallel_threads(1))
 
     if not hasattr(item, "obj"):
@@ -168,12 +171,15 @@ def pytest_itemcollected(item):
     ]
     skipped_functions = {(".".join(x[:-1]), x[-1]) for x in skipped_functions}
 
-    if n_workers > 1 and identify_thread_unsafe_nodes(item.obj, skipped_functions):
-        n_workers = 1
-        item.user_properties.append(
-            ("thread_unsafe_reason", "calls thread-unsafe function")
-        )
-        item.add_marker(pytest.mark.parallel_threads(1))
+    if n_workers > 1:
+        thread_unsafe, thread_unsafe_reason = identify_thread_unsafe_nodes(
+            item.obj, skipped_functions)
+        if thread_unsafe:
+            n_workers = 1
+            item.user_properties.append(
+                ("thread_unsafe_reason", thread_unsafe_reason)
+            )
+            item.add_marker(pytest.mark.parallel_threads(1))
 
     unsafe_fixtures = _thread_unsafe_fixtures | set(
         item.config.getini("thread_unsafe_fixtures")
@@ -181,8 +187,10 @@ def pytest_itemcollected(item):
 
     if n_workers > 1 and any(fixture in fixtures for fixture in unsafe_fixtures):
         n_workers = 1
+        used_unsafe_fixtures = unsafe_fixtures | set(fixtures)
         item.user_properties.append(
-            ("thread_unsafe_reason", "uses thread-unsafe fixture")
+            ("thread_unsafe_reason",
+             f"uses thread-unsafe fixture(s) {used_unsafe_fixtures}")
         )
         item.add_marker(pytest.mark.parallel_threads(1))
 
@@ -224,7 +232,7 @@ def pytest_report_teststatus(report, config):
             return (
                 "passed",
                 ".",
-                f"PASSED ([thread-unsafe]: {props['thread_unsafe_reason']})",
+                f"PASSED [thread-unsafe]: {props['thread_unsafe_reason']}",
             )
         if report.outcome == "failed":
             return (
@@ -254,7 +262,12 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
                 report_props = dict(report.user_properties)
                 if "n_threads" not in report_props:
                     if verbose_tests:
-                        terminalreporter.line(f"{report.nodeid} {report_props}")
+                        reason = report_props.get('thread_unsafe_reason', None)
+                        if reason:
+                            terminalreporter.line(
+                                f"{report.nodeid} skipped with reason: \"{reason}\"")
+                        else:
+                            terminalreporter.line(report.nodeid)
                     num_serial += 1
 
     if n_workers > 1 and not verbose_tests:

--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -9,8 +9,8 @@ import pytest
 
 from pytest_run_parallel.utils import (
     ThreadComparator,
-    get_num_workers,
     get_configured_num_workers,
+    get_num_workers,
     identify_thread_unsafe_nodes,
 )
 
@@ -145,8 +145,9 @@ def pytest_itemcollected(item):
         if reason is not None:
             item.user_properties.append(("thread_unsafe_reason", reason))
         else:
-            item.user_properties.append(("thread_unsafe_reason",
-                                         "uses thread_unsafe marker"))
+            item.user_properties.append(
+                ("thread_unsafe_reason", "uses thread_unsafe marker")
+            )
         item.add_marker(pytest.mark.parallel_threads(1))
 
     if not hasattr(item, "obj"):
@@ -173,12 +174,11 @@ def pytest_itemcollected(item):
 
     if n_workers > 1:
         thread_unsafe, thread_unsafe_reason = identify_thread_unsafe_nodes(
-            item.obj, skipped_functions)
+            item.obj, skipped_functions
+        )
         if thread_unsafe:
             n_workers = 1
-            item.user_properties.append(
-                ("thread_unsafe_reason", thread_unsafe_reason)
-            )
+            item.user_properties.append(("thread_unsafe_reason", thread_unsafe_reason))
             item.add_marker(pytest.mark.parallel_threads(1))
 
     unsafe_fixtures = _thread_unsafe_fixtures | set(
@@ -189,8 +189,10 @@ def pytest_itemcollected(item):
         n_workers = 1
         used_unsafe_fixtures = unsafe_fixtures | set(fixtures)
         item.user_properties.append(
-            ("thread_unsafe_reason",
-             f"uses thread-unsafe fixture(s) {used_unsafe_fixtures}")
+            (
+                "thread_unsafe_reason",
+                f"uses thread-unsafe fixture(s) {used_unsafe_fixtures}",
+            )
         )
         item.add_marker(pytest.mark.parallel_threads(1))
 
@@ -262,10 +264,11 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
                 report_props = dict(report.user_properties)
                 if "n_threads" not in report_props:
                     if verbose_tests:
-                        reason = report_props.get('thread_unsafe_reason', None)
+                        reason = report_props.get("thread_unsafe_reason", None)
                         if reason:
                             terminalreporter.line(
-                                f"{report.nodeid} skipped with reason: \"{reason}\"")
+                                f'{report.nodeid} skipped with reason: "{reason}"'
+                            )
                         else:
                             terminalreporter.line(report.nodeid)
                     num_serial += 1

--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -170,7 +170,8 @@ def pytest_itemcollected(item):
     if identify_thread_unsafe_nodes(item.obj, skipped_functions):
         n_workers = 1
         item.user_properties.append(
-            ('thread_unsafe_reason', 'calls thread-unsafe function'))
+            ("thread_unsafe_reason", "calls thread-unsafe function")
+        )
         item.add_marker(pytest.mark.parallel_threads(1))
 
     unsafe_fixtures = _thread_unsafe_fixtures | set(
@@ -180,7 +181,8 @@ def pytest_itemcollected(item):
     if any(fixture in fixtures for fixture in unsafe_fixtures):
         n_workers = 1
         item.user_properties.append(
-            ('thread_unsafe_reason', 'uses thread-unsafe fixture'))
+            ("thread_unsafe_reason", "uses thread-unsafe fixture")
+        )
         item.add_marker(pytest.mark.parallel_threads(1))
 
     if n_workers > 1 or n_iterations > 1:

--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -138,7 +138,7 @@ def pytest_itemcollected(item):
         n_iterations = int(m.args[0])
 
     m = item.get_closest_marker("thread_unsafe")
-    if m is not None:
+    if n_workers > 1 and m is not None:
         n_workers = 1
         reason = m.kwargs.get("reason", None)
         if reason is not None:
@@ -167,7 +167,7 @@ def pytest_itemcollected(item):
     ]
     skipped_functions = {(".".join(x[:-1]), x[-1]) for x in skipped_functions}
 
-    if identify_thread_unsafe_nodes(item.obj, skipped_functions):
+    if n_workers > 1 and identify_thread_unsafe_nodes(item.obj, skipped_functions):
         n_workers = 1
         item.user_properties.append(
             ("thread_unsafe_reason", "calls thread-unsafe function")
@@ -178,7 +178,7 @@ def pytest_itemcollected(item):
         item.config.getini("thread_unsafe_fixtures")
     )
 
-    if any(fixture in fixtures for fixture in unsafe_fixtures):
+    if n_workers > 1 and any(fixture in fixtures for fixture in unsafe_fixtures):
         n_workers = 1
         item.user_properties.append(
             ("thread_unsafe_reason", "uses thread-unsafe fixture")

--- a/src/pytest_run_parallel/utils.py
+++ b/src/pytest_run_parallel/utils.py
@@ -64,7 +64,9 @@ class ThreadUnsafeNodeVisitor(ast.NodeVisitor):
                     real_mod = self.modules_aliases[real_mod]
                 if (real_mod, node.func.attr) in self.blacklist:
                     self.thread_unsafe = True
-                    self.thread_unsafe_reason = f"calls thread-unsafe function: {node.func.attr}"
+                    self.thread_unsafe_reason = (
+                        f"calls thread-unsafe function: {node.func.attr}"
+                    )
                 elif self.level < 2:
                     if node.func.value.id in getattr(self.fn, "__globals__", {}):
                         mod = self.fn.__globals__[node.func.value.id]
@@ -80,7 +82,9 @@ class ThreadUnsafeNodeVisitor(ast.NodeVisitor):
             if node.func.id in self.func_aliases:
                 if self.func_aliases[node.func.id] in self.blacklist:
                     self.thread_unsafe = True
-                    self.thread_unsafe_reason = f"calls thread-unsafe function: {node.func.id}"
+                    self.thread_unsafe_reason = (
+                        f"calls thread-unsafe function: {node.func.id}"
+                    )
                     recurse = False
             if recurse and self.level < 2:
                 if node.func.id in getattr(self.fn, "__globals__", {}):
@@ -102,7 +106,8 @@ class ThreadUnsafeNodeVisitor(ast.NodeVisitor):
                 self.thread_unsafe = not bool(value_node.value)
                 self.thread_unsafe_reason = (
                     f"calls thread-unsafe function: f{name_node} "
-                    "(inferred via func.__thread_safe__ == False)")
+                    "(inferred via func.__thread_safe__ == False)"
+                )
 
 
 def identify_thread_unsafe_nodes(fn, skip_set, level=0):

--- a/src/pytest_run_parallel/utils.py
+++ b/src/pytest_run_parallel/utils.py
@@ -211,14 +211,18 @@ def get_logical_cpus():
     return cpu_count()
 
 
-def get_num_workers(config, item):
+def get_configured_num_workers(config):
     n_workers = config.option.parallel_threads
     if n_workers == "auto":
         logical_cpus = get_logical_cpus()
         n_workers = logical_cpus if logical_cpus is not None else 1
     else:
         n_workers = int(n_workers)
+    return n_workers
 
+
+def get_num_workers(config, item):
+    n_workers = get_configured_num_workers(config)
     marker = item.get_closest_marker("parallel_threads")
     if marker is not None:
         val = marker.args[0]

--- a/tests/test_run_parallel.py
+++ b/tests/test_run_parallel.py
@@ -940,6 +940,8 @@ def test_thread_unsafe_function_attr(pytester):
     """)
 
     # run pytest with the following cmd args
+    orig = os.environ.get("PYTEST_RUN_PARALLEL_VERBOSE", "0")
+    os.environ["PYTEST_RUN_PARALLEL_VERBOSE"] = "0"
     result = pytester.runpytest("--parallel-threads=10", "-v")
 
     # fnmatch_lines does an assertion internally
@@ -950,6 +952,12 @@ def test_thread_unsafe_function_attr(pytester):
             "*::test_should_not_be_marked PARALLEL PASSED*",
             "*::test_should_be_marked_2 PASSED*",
             "*::test_should_be_marked_3 PASSED*",
+        ]
+    )
+
+
+    result.stdout.fnmatch_lines(
+        [
             "*3 tests were not run in parallel because of use of thread-unsafe "
             "functionality, to list the tests that were skipped, "
             "re-run while setting PYTEST_RUN_PARALLEL_VERBOSE=1 in your "
@@ -960,7 +968,7 @@ def test_thread_unsafe_function_attr(pytester):
     # re-run with PYTEST_RUN_PARALLEL_VERBOSE=1
     os.environ["PYTEST_RUN_PARALLEL_VERBOSE"] = "1"
     result = pytester.runpytest("--parallel-threads=10", "-v")
-    os.environ["PYTEST_RUN_PARALLEL_VERBOSE"] = "0"
+    os.environ["PYTEST_RUN_PARALLEL_VERBOSE"] = orig
 
     result.stdout.fnmatch_lines(
         [

--- a/tests/test_run_parallel.py
+++ b/tests/test_run_parallel.py
@@ -209,7 +209,7 @@ def test_skip(pytester):
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines(
         [
-            "*::test_skipped SKIPPED*",
+            "*::test_skipped PARALLEL SKIPPED*",
         ]
     )
 
@@ -234,7 +234,7 @@ def test_fail(pytester):
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines(
         [
-            "*::test_should_fail FAILED*",
+            "*::test_should_fail PARALLEL FAILED*",
         ]
     )
 

--- a/tests/test_run_parallel.py
+++ b/tests/test_run_parallel.py
@@ -1,6 +1,6 @@
+import os
 from contextlib import suppress
 
-import os
 import pytest
 
 try:
@@ -346,7 +346,7 @@ def test_thread_comp_fixture(pytester):
     result.stdout.fnmatch_lines(
         [
             "*::test_value_comparison PARALLEL PASSED*",
-            "*::test_comparison_fail PARALLEL FAILED*"
+            "*::test_comparison_fail PARALLEL FAILED*",
         ]
     )
 
@@ -953,14 +953,14 @@ def test_thread_unsafe_function_attr(pytester):
             "*3 tests were not run in parallel because of use of thread-unsafe "
             "functionality, to list the tests that were skipped, "
             "re-run while setting PYTEST_RUN_PARALLEL_VERBOSE=1 in your "
-            "shell environment*"
+            "shell environment*",
         ]
     )
 
     # re-run with PYTEST_RUN_PARALLEL_VERBOSE=1
-    os.environ['PYTEST_RUN_PARALLEL_VERBOSE'] = '1'
+    os.environ["PYTEST_RUN_PARALLEL_VERBOSE"] = "1"
     result = pytester.runpytest("--parallel-threads=10", "-v")
-    os.environ['PYTEST_RUN_PARALLEL_VERBOSE'] = '0'
+    os.environ["PYTEST_RUN_PARALLEL_VERBOSE"] = "0"
 
     result.stdout.fnmatch_lines(
         [
@@ -971,7 +971,7 @@ def test_thread_unsafe_function_attr(pytester):
             "*::test_should_be_marked_3 PASSED*",
             "*::test_should_be_marked_1*",
             "*::test_should_be_marked_2*",
-            "*::test_should_be_marked_3*"
+            "*::test_should_be_marked_3*",
         ]
     )
 

--- a/tests/test_run_parallel.py
+++ b/tests/test_run_parallel.py
@@ -955,7 +955,6 @@ def test_thread_unsafe_function_attr(pytester):
         ]
     )
 
-
     result.stdout.fnmatch_lines(
         [
             "*3 tests were not run in parallel because of use of thread-unsafe "

--- a/tests/test_run_parallel.py
+++ b/tests/test_run_parallel.py
@@ -948,10 +948,10 @@ def test_thread_unsafe_function_attr(pytester):
     result.stdout.fnmatch_lines(
         [
             "*Collected 1 items to run in parallel*",
-            "*::test_should_be_marked_1 PASSED *thread-unsafe*: calls thread-unsafe function*",
+            "*::test_should_be_marked_1 PASSED *thread-unsafe*inferred via func.__thread_safe__*",
             "*::test_should_not_be_marked PARALLEL PASSED*",
-            "*::test_should_be_marked_2 PASSED*",
-            "*::test_should_be_marked_3 PASSED*",
+            "*::test_should_be_marked_2 PASSED *thread-unsafe*marked_for_skip*",
+            "*::test_should_be_marked_3 PASSED *thread-unsafe*inferred via func.__thread_safe__*",
         ]
     )
 

--- a/tests/test_run_parallel.py
+++ b/tests/test_run_parallel.py
@@ -1,5 +1,6 @@
 from contextlib import suppress
 
+import os
 import pytest
 
 try:
@@ -209,7 +210,7 @@ def test_skip(pytester):
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines(
         [
-            "*::test_skipped PARALLEL SKIPPED*",
+            "*::test_skipped SKIPPED*",
         ]
     )
 
@@ -259,7 +260,7 @@ def test_exception(pytester):
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines(
         [
-            "*::test_should_fail FAILED*",
+            "*::test_should_fail PARALLEL FAILED*",
         ]
     )
 
@@ -288,8 +289,8 @@ def test_num_parallel_threads_fixture(pytester):
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines(
         [
-            "*::test_should_yield_global_threads PASSED*",
-            "*::test_should_yield_marker_threads PASSED*",
+            "*::test_should_yield_global_threads PARALLEL PASSED*",
+            "*::test_should_yield_marker_threads PARALLEL PASSED*",
         ]
     )
 
@@ -343,7 +344,10 @@ def test_thread_comp_fixture(pytester):
 
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines(
-        ["*::test_value_comparison PASSED*", "*::test_comparison_fail FAILED*"]
+        [
+            "*::test_value_comparison PARALLEL PASSED*",
+            "*::test_comparison_fail PARALLEL FAILED*"
+        ]
     )
 
 
@@ -542,6 +546,10 @@ def test_thread_unsafe_marker(pytester):
         @pytest.mark.thread_unsafe
         def test_should_run_single(num_parallel_threads):
             assert num_parallel_threads == 1
+
+        @pytest.mark.thread_unsafe(reason='this is thread-unsafe')
+        def test_should_run_single_2(num_parallel_threads):
+            assert num_parallel_threads == 1
     """)
 
     # run pytest with the following cmd args
@@ -551,6 +559,7 @@ def test_thread_unsafe_marker(pytester):
     result.stdout.fnmatch_lines(
         [
             "*::test_should_run_single PASSED*",
+            "*::test_should_run_single_2 PASSED *thread-unsafe*: this is thread-unsafe*",
         ]
     )
 
@@ -623,7 +632,7 @@ def test_auto_detect_cpus_psutil_affinity(
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines(
         [
-            "*::test_auto_detect_cpus PASSED*",
+            "*::test_auto_detect_cpus PARALLEL PASSED*",
         ]
     )
 
@@ -650,7 +659,7 @@ def test_auto_detect_cpus_psutil_cpu_count(
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines(
         [
-            "*::test_auto_detect_cpus PASSED*",
+            "*::test_auto_detect_cpus PARALLEL PASSED*",
         ]
     )
 
@@ -682,7 +691,7 @@ def test_auto_detect_process_cpu_count(
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines(
         [
-            "*::test_auto_detect_cpus PASSED*",
+            "*::test_auto_detect_cpus PARALLEL PASSED*",
         ]
     )
 
@@ -716,7 +725,7 @@ def test_auto_detect_sched_getaffinity(
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines(
         [
-            "*::test_auto_detect_cpus PASSED*",
+            "*::test_auto_detect_cpus PARALLEL PASSED*",
         ]
     )
 
@@ -747,7 +756,7 @@ def test_auto_detect_cpu_count(
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines(
         [
-            "*::test_auto_detect_cpus PASSED*",
+            "*::test_auto_detect_cpus PARALLEL PASSED*",
         ]
     )
 
@@ -791,10 +800,10 @@ def test_thread_unsafe_fixtures(pytester):
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines(
         [
-            "*::test_capsys PASSED*",
-            "*::test_recwarn PASSED*",
-            "*::test_custom_fixture_skip PASSED*",
-            "*::test_custom_fixture_skip_2 PASSED*",
+            "*::test_capsys PASSED *thread-unsafe*: uses thread-unsafe fixture*",
+            "*::test_recwarn PASSED *thread-unsafe*: uses thread-unsafe fixture*",
+            "*::test_custom_fixture_skip PASSED *thread-unsafe*: uses thread-unsafe fixture*",
+            "*::test_custom_fixture_skip_2 PASSED *thread-unsafe*: uses thread-unsafe fixture*",
         ]
     )
 
@@ -936,10 +945,33 @@ def test_thread_unsafe_function_attr(pytester):
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines(
         [
-            "*::test_should_be_marked_1 PASSED*",
-            "*::test_should_not_be_marked PASSED*",
+            "*Collected 1 items to run in parallel*",
+            "*::test_should_be_marked_1 PASSED *thread-unsafe*: calls thread-unsafe function*",
+            "*::test_should_not_be_marked PARALLEL PASSED*",
             "*::test_should_be_marked_2 PASSED*",
             "*::test_should_be_marked_3 PASSED*",
+            "*3 tests were not run in parallel because of use of thread-unsafe "
+            "functionality, to list the tests that were skipped, "
+            "re-run while setting PYTEST_RUN_PARALLEL_VERBOSE=1 in your "
+            "shell environment*"
+        ]
+    )
+
+    # re-run with PYTEST_RUN_PARALLEL_VERBOSE=1
+    os.environ['PYTEST_RUN_PARALLEL_VERBOSE'] = '1'
+    result = pytester.runpytest("--parallel-threads=10", "-v")
+    os.environ['PYTEST_RUN_PARALLEL_VERBOSE'] = '0'
+
+    result.stdout.fnmatch_lines(
+        [
+            "*Collected 1 items to run in parallel*",
+            "*::test_should_be_marked_1 PASSED *thread-unsafe*: calls thread-unsafe function*",
+            "*::test_should_not_be_marked PARALLEL PASSED*",
+            "*::test_should_be_marked_2 PASSED*",
+            "*::test_should_be_marked_3 PASSED*",
+            "*::test_should_be_marked_1*",
+            "*::test_should_be_marked_2*",
+            "*::test_should_be_marked_3*"
         ]
     )
 


### PR DESCRIPTION
Fixes #41

This PR allows pytest-run-parallel to report the number of collected tests that will run in parallel, it also now reports if a parallel test has passed, failed or skipped under parallel conditions. For instance, if a test passes and pytest is running in verbose mode, then it will show `PARALLEL PASSED` as opposed to `PASSED` when a test runs in a single thread 