### PR TITLE
Upgrade gh-action-pypi-publish to fix metadata error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,4 +45,4 @@ jobs:
           path: dist/
 
       - name: Publish release distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.10.2
+        uses: pypa/gh-action-pypi-publish@v1.12.4


### PR DESCRIPTION
The last run of our `release` workflow [failed with a metadata error](https://github.com/Quansight-Labs/pytest-run-parallel/actions/runs/14523161708/job/40748627526#step:4:13). Upgrading `gh-action-pypi-publish` to the latest version should fix it.