### PR TITLE
Report manually marked single-threaded tests

### DIFF
--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -262,7 +262,7 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
         for report in reports:
             if getattr(report, "when", None) == "call":
                 report_props = dict(report.user_properties)
-                if "n_threads" not in report_props:
+                if "n_threads" not in report_props or report_props['n_threads'] == 1:
                     if verbose_tests:
                         reason = report_props.get("thread_unsafe_reason", None)
                         if reason:

--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -279,8 +279,8 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
                 "while setting PYTEST_RUN_PARALLEL_VERBOSE=1 "
                 "in your shell environment"
             )
-        else:
-            terminalreporter.line("All tests were run in parallel! 🎉")
+    if n_workers > 1 and num_serial == 0:
+        terminalreporter.line("All tests were run in parallel! 🎉")
 
 
 @pytest.fixture

--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -250,10 +250,7 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
     verbose_tests = bool(int(os.environ.get("PYTEST_RUN_PARALLEL_VERBOSE", "0")))
     n_workers = get_configured_num_workers(config)
     if n_workers > 1:
-        if verbose_tests:
-            terminalreporter.write_sep("*", "List of tests *not* run in parallel")
-        else:
-            terminalreporter.write_sep("*", "Some tests *not* run in parallel")
+        terminalreporter.write_sep("*", "pytest-run-parallel report")
 
     num_serial = 0
     stats = terminalreporter.stats
@@ -274,13 +271,16 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
                     num_serial += 1
 
     if n_workers > 1 and not verbose_tests:
-        terminalreporter.line(
-            f"{num_serial} tests were not run in parallel "
-            "because of use of thread-unsafe functionality, "
-            "to list the tests that were skipped, re-run "
-            "while setting PYTEST_RUN_PARALLEL_VERBOSE=1 "
-            "in your shell environment"
-        )
+        if num_serial > 0:
+            terminalreporter.line(
+                f"{num_serial} tests were not run in parallel "
+                "because of use of thread-unsafe functionality, "
+                "to list the tests that were skipped, re-run "
+                "while setting PYTEST_RUN_PARALLEL_VERBOSE=1 "
+                "in your shell environment"
+            )
+        else:
+            terminalreporter.line("All tests were run in parallel! 🎉")
 
 
 @pytest.fixture

--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -262,7 +262,7 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
         for report in reports:
             if getattr(report, "when", None) == "call":
                 report_props = dict(report.user_properties)
-                if "n_threads" not in report_props or report_props['n_threads'] == 1:
+                if "n_threads" not in report_props or report_props["n_threads"] == 1:
                     if verbose_tests:
                         reason = report_props.get("thread_unsafe_reason", None)
                         if reason:

--- a/tests/test_run_parallel.py
+++ b/tests/test_run_parallel.py
@@ -1025,3 +1025,32 @@ def test_detect_hypothesis(pytester):
             "*::test_uses_hypothesis PASSED*",
         ]
     )
+
+
+def test_all_tests_in_parallel(pytester):
+    pytester.makepyfile("""
+    def test_parallel_1(num_parallel_threads):
+        assert num_parallel_threads == 10
+
+    def test_parallel_2(num_parallel_threads):
+        assert num_parallel_threads == 10
+    """)
+
+    result = pytester.runpytest("--parallel-threads=10", "-v")
+    result.stdout.fnmatch_lines(
+        [
+            "*All tests were run in parallel! 🎉*",
+        ]
+    )
+
+    # re-run with PYTEST_RUN_PARALLEL_VERBOSE=1
+    orig = os.environ.get("PYTEST_RUN_PARALLEL_VERBOSE", "0")
+    os.environ["PYTEST_RUN_PARALLEL_VERBOSE"] = "1"
+    result = pytester.runpytest("--parallel-threads=10", "-v")
+    os.environ["PYTEST_RUN_PARALLEL_VERBOSE"] = orig
+
+    result.stdout.fnmatch_lines(
+        [
+            "*All tests were run in parallel! 🎉*",
+        ]
+    )

--- a/tests/test_run_parallel.py
+++ b/tests/test_run_parallel.py
@@ -299,7 +299,7 @@ def test_num_parallel_threads_fixture(pytester):
             "*1 tests were not run in parallel because of use of "
             "thread-unsafe functionality, to list the tests that "
             "were skipped, re-run while setting PYTEST_RUN_PARALLEL_VERBOSE=1"
-            " in your shell environment"
+            " in your shell environment",
         ]
     )
 
@@ -311,11 +311,8 @@ def test_num_parallel_threads_fixture(pytester):
     os.environ["PYTEST_RUN_PARALLEL_VERBOSE"] = orig
 
     result.stdout.fnmatch_lines(
-        [
-            "*List of tests *not* run in parallel*",
-            "*::test_single_threaded*"
-        ],
-        consecutive=True
+        ["*List of tests *not* run in parallel*", "*::test_single_threaded*"],
+        consecutive=True,
     )
 
 

--- a/tests/test_run_parallel.py
+++ b/tests/test_run_parallel.py
@@ -1009,7 +1009,7 @@ def test_thread_unsafe_function_attr(pytester):
     )
 
 
-@pytest.mark.skipif(hypothesis is None, reason='hypothesis needs to be installed')
+@pytest.mark.skipif(hypothesis is None, reason="hypothesis needs to be installed")
 def test_detect_hypothesis(pytester):
     pytester.makepyfile("""
     from hypothesis import given, strategies as st, settings, HealthCheck

--- a/tests/test_run_parallel.py
+++ b/tests/test_run_parallel.py
@@ -9,6 +9,11 @@ except ImportError:
     psutil = None
 
 try:
+    import hypothesis
+except ImportError:
+    hypothesis = None
+
+try:
     from os import process_cpu_count
 except ImportError:
     process_cpu_count = None
@@ -311,7 +316,7 @@ def test_num_parallel_threads_fixture(pytester):
     os.environ["PYTEST_RUN_PARALLEL_VERBOSE"] = orig
 
     result.stdout.fnmatch_lines(
-        ["*List of tests *not* run in parallel*", "*::test_single_threaded*"],
+        ["*pytest-run-parallel report*", "*::test_single_threaded*"],
         consecutive=True,
     )
 
@@ -1004,6 +1009,7 @@ def test_thread_unsafe_function_attr(pytester):
     )
 
 
+@pytest.mark.skipif(hypothesis is None, reason='hypothesis needs to be installed')
 def test_detect_hypothesis(pytester):
     pytester.makepyfile("""
     from hypothesis import given, strategies as st, settings, HealthCheck


### PR DESCRIPTION
Fixes #46 

This PR enables reporting tests that were marked as single-threaded using `@pytest.mark.parallel_threads(1)`, as they were not being reported before 