### PR TITLE
Detect unsafe calls that occur under assigments

### DIFF
--- a/src/pytest_run_parallel/utils.py
+++ b/src/pytest_run_parallel/utils.py
@@ -111,6 +111,8 @@ class ThreadUnsafeNodeVisitor(ast.NodeVisitor):
                     f"calls thread-unsafe function: f{name_node} "
                     "(inferred via func.__thread_safe__ == False)"
                 )
+            else:
+                self.generic_visit(node)
 
 
 def identify_thread_unsafe_nodes(fn, skip_set, level=0):

--- a/tests/test_run_parallel.py
+++ b/tests/test_run_parallel.py
@@ -1054,3 +1054,20 @@ def test_all_tests_in_parallel(pytester):
             "*All tests were run in parallel! 🎉*",
         ]
     )
+
+
+def test_recurse_assign(pytester):
+    pytester.makepyfile("""
+    import pytest
+
+    def test_function_recurse_on_assign(num_parallel_threads):
+        w = pytest.warns(UserWarning)
+        assert num_parallel_threads == 1
+    """)
+
+    result = pytester.runpytest("--parallel-threads=10", "-v")
+    result.stdout.fnmatch_lines(
+        [
+            "*::test_function_recurse_on_assign PASSED*",
+        ]
+    )


### PR DESCRIPTION
Fixes #50 

Apparently, the call to `visit_Assign` was not recursing on its children, therefore, assignments that had target calls to blacklisted functions were not being covered, by recursing now, it works as expected.