### PR TITLE
detect unitest.mock use and skip parallel tests for tests that use it

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,6 +135,7 @@ pytest-run-parallel will automatically not run tests using them in parallel:
 * ``pytest.deprecated_call``
 * The pytest ``recwarn`` fixture
 * ``warnings.catch_warnings``
+* ``unittest.mock``
 * Any test using `hypothesis <https://hypothesis.readthedocs.io/en/latest/>`_.
 
 Additionally, if a set of fixtures is known to be thread unsafe, tests that use

--- a/src/pytest_run_parallel/utils.py
+++ b/src/pytest_run_parallel/utils.py
@@ -69,8 +69,7 @@ class ThreadUnsafeNodeVisitor(ast.NodeVisitor):
                 if (real_mod, node.func.attr) in self.blacklist:
                     self.thread_unsafe = True
                     self.thread_unsafe_reason = (
-                        "calls thread-unsafe function: "
-                        f"{real_mod}.{node.func.attr}"
+                        "calls thread-unsafe function: " f"{real_mod}.{node.func.attr}"
                     )
                 elif self.level < 2:
                     if node.func.value.id in getattr(self.fn, "__globals__", {}):

--- a/src/pytest_run_parallel/utils.py
+++ b/src/pytest_run_parallel/utils.py
@@ -34,6 +34,7 @@ class ThreadUnsafeNodeVisitor(ast.NodeVisitor):
             ("_pytest.recwarn", "warns"),
             ("_pytest.recwarn", "deprecated_call"),
             ("warnings", "catch_warnings"),
+            ("mock", "patch"),  # unittest.mock
         } | set(skip_set)
         modules = {mod.split(".")[0] for mod, _ in self.blacklist}
         modules |= {mod for mod, _ in self.blacklist}
@@ -68,7 +69,8 @@ class ThreadUnsafeNodeVisitor(ast.NodeVisitor):
                 if (real_mod, node.func.attr) in self.blacklist:
                     self.thread_unsafe = True
                     self.thread_unsafe_reason = (
-                        f"calls thread-unsafe function: {node.func.attr}"
+                        "calls thread-unsafe function: "
+                        f"{real_mod}.{node.func.attr}"
                     )
                 elif self.level < 2:
                     if node.func.value.id in getattr(self.fn, "__globals__", {}):

--- a/tests/test_run_parallel.py
+++ b/tests/test_run_parallel.py
@@ -1040,8 +1040,7 @@ def test_detect_unittest_mock(pytester):
     result = pytester.runpytest("--parallel-threads=10", "-v")
     result.stdout.fnmatch_lines(
         [
-            r"*::test_uses_mock PASSED*"
-            r"calls thread-unsafe function: mock.patch*",
+            r"*::test_uses_mock PASSED*" r"calls thread-unsafe function: mock.patch*",
         ]
     )
 

--- a/tests/test_run_parallel.py
+++ b/tests/test_run_parallel.py
@@ -1027,6 +1027,25 @@ def test_detect_hypothesis(pytester):
     )
 
 
+def test_detect_unittest_mock(pytester):
+    pytester.makepyfile("""
+    import sys
+    from unittest import mock
+
+    @mock.patch("sys.platform", "VAX")
+    def test_uses_mock(num_parallel_threads):
+        assert sys.platform == "VAX"
+        assert num_parallel_threads == 1
+    """)
+    result = pytester.runpytest("--parallel-threads=10", "-v")
+    result.stdout.fnmatch_lines(
+        [
+            r"*::test_uses_mock PASSED*"
+            r"calls thread-unsafe function: mock.patch*",
+        ]
+    )
+
+
 def test_all_tests_in_parallel(pytester):
     pytester.makepyfile("""
     def test_parallel_1(num_parallel_threads):


### PR DESCRIPTION
I hit this trying the `argon2-cffi` tests using `pytest-run-parallel`.