### PR TITLE
attempt to fix 32 bit architectures

### DIFF
--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -65,52 +65,55 @@ def pytest_configure(config):
 
 
 def wrap_function_parallel(fn, n_workers, n_iterations):
-    barrier = threading.Barrier(n_workers)
-    original_switch = sys.getswitchinterval()
-    sys.setswitchinterval(0.000001)
-
     @functools.wraps(fn)
     def inner(*args, **kwargs):
         errors = []
         skip = None
         failed = None
-
-        def closure(*args, **kwargs):
-            for _ in range(n_iterations):
-                barrier.wait()
-                try:
-                    fn(*args, **kwargs)
-                except Warning:
-                    pass
-                except Exception as e:
-                    errors.append(e)
-                except _pytest.outcomes.Skipped as s:
-                    nonlocal skip
-                    skip = s.msg
-                except _pytest.outcomes.Failed as f:
-                    nonlocal failed
-                    failed = f
-
-        workers = []
-        for _ in range(0, n_workers):
-            worker_kwargs = kwargs
-            workers.append(
-                threading.Thread(target=closure, args=args, kwargs=worker_kwargs)
-            )
-
-        num_completed = 0
+        barrier = threading.Barrier(n_workers)
+        original_switch = sys.getswitchinterval()
         try:
+            sys.setswitchinterval(0.000001)
+
+            def closure(*args, **kwargs):
+                for _ in range(n_iterations):
+                    barrier.wait()
+                    try:
+                        fn(*args, **kwargs)
+                    except Warning:
+                        pass
+                    except Exception as e:
+                        errors.append(e)
+                    except _pytest.outcomes.Skipped as s:
+                        nonlocal skip
+                        skip = s.msg
+                    except _pytest.outcomes.Failed as f:
+                        nonlocal failed
+                        failed = f
+
+            workers = []
+            for _ in range(0, n_workers):
+                worker_kwargs = kwargs
+                workers.append(
+                    threading.Thread(
+                        target=closure, args=args, kwargs=worker_kwargs
+                    )
+                )
+
+            num_completed = 0
+            try:
+                for worker in workers:
+                    worker.start()
+                    num_completed += 1
+            finally:
+                if num_completed < len(workers):
+                    barrier.abort()
+
             for worker in workers:
-                worker.start()
-                num_completed += 1
+                worker.join()
+
         finally:
-            if num_completed < len(workers):
-                barrier.abort()
-
-        for worker in workers:
-            worker.join()
-
-        sys.setswitchinterval(original_switch)
+            sys.setswitchinterval(original_switch)
 
         if skip is not None:
             pytest.skip(skip)

--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -95,9 +95,7 @@ def wrap_function_parallel(fn, n_workers, n_iterations):
             for _ in range(0, n_workers):
                 worker_kwargs = kwargs
                 workers.append(
-                    threading.Thread(
-                        target=closure, args=args, kwargs=worker_kwargs
-                    )
+                    threading.Thread(target=closure, args=args, kwargs=worker_kwargs)
                 )
 
             num_completed = 0


### PR DESCRIPTION
Fixes #53.

For reasons I don't understand, binding `orig_interval` in the outer function scope doesn't always work on 32 bit python.

I also took the opportunity to make sure calling `sys.setswitchinterval(orig_interval)` always happens after we set it to 10 microseconds in the pytest plugin using a `try/finally` block.

I manually verified this works on a 32 bit linux docker image from manylinux. I don't particularly want to fight with github actions to figure out how to add 32 bit CI. If anyone wants to take that on, please feel free.