### PR TITLE
use an lru_cache to speed up recursive ast parsing

### DIFF
--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -172,8 +172,7 @@ def pytest_itemcollected(item):
     skipped_functions = [
         x.split(".") for x in item.config.getini("thread_unsafe_functions")
     ]
-    skipped_functions = frozenset((".".join(x[:-1]), x[-1]) for x in
-                                  skipped_functions)
+    skipped_functions = {(".".join(x[:-1]), x[-1]) for x in skipped_functions}
 
     if n_workers > 1:
         thread_unsafe, thread_unsafe_reason = identify_thread_unsafe_nodes(

--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -172,7 +172,7 @@ def pytest_itemcollected(item):
     skipped_functions = [
         x.split(".") for x in item.config.getini("thread_unsafe_functions")
     ]
-    skipped_functions = {(".".join(x[:-1]), x[-1]) for x in skipped_functions}
+    skipped_functions = frozenset((".".join(x[:-1]), x[-1]) for x in skipped_functions)
 
     if n_workers > 1:
         thread_unsafe, thread_unsafe_reason = identify_thread_unsafe_nodes(

--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -172,7 +172,8 @@ def pytest_itemcollected(item):
     skipped_functions = [
         x.split(".") for x in item.config.getini("thread_unsafe_functions")
     ]
-    skipped_functions = {(".".join(x[:-1]), x[-1]) for x in skipped_functions}
+    skipped_functions = frozenset((".".join(x[:-1]), x[-1]) for x in
+                                  skipped_functions)
 
     if n_workers > 1:
         thread_unsafe, thread_unsafe_reason = identify_thread_unsafe_nodes(

--- a/src/pytest_run_parallel/utils.py
+++ b/src/pytest_run_parallel/utils.py
@@ -134,7 +134,10 @@ cached_thread_unsafe_identify = functools.lru_cache(_identify_thread_unsafe_node
 
 
 def identify_thread_unsafe_nodes(fn, skip_set, level=0):
-    return cached_thread_unsafe_identify(fn, skip_set, level=level)
+    try:
+        return cached_thread_unsafe_identify(fn, skip_set, level=level)
+    except TypeError:
+        return _identify_thread_unsafe_nodes(fn, skip_set, level=level)
 
 
 class ThreadComparator:

--- a/src/pytest_run_parallel/utils.py
+++ b/src/pytest_run_parallel/utils.py
@@ -134,11 +134,7 @@ cached_thread_unsafe_identify = functools.lru_cache(_identify_thread_unsafe_node
 
 
 def identify_thread_unsafe_nodes(fn, skip_set, level=0):
-    try:
-        return cached_thread_unsafe_identify(fn, skip_set, level=level)
-    except TypeError:
-        # skip caching if we hit an error about fn not being hashable
-        return _identify_thread_unsafe_nodes(fn, skip_set, level=level)
+    return cached_thread_unsafe_identify(fn, skip_set, level=level)
 
 
 class ThreadComparator:

--- a/src/pytest_run_parallel/utils.py
+++ b/src/pytest_run_parallel/utils.py
@@ -1,4 +1,5 @@
 import ast
+import functools
 import inspect
 import threading
 import types
@@ -116,6 +117,7 @@ class ThreadUnsafeNodeVisitor(ast.NodeVisitor):
                 self.generic_visit(node)
 
 
+@functools.lru_cache
 def identify_thread_unsafe_nodes(fn, skip_set, level=0):
     if is_hypothesis_test(fn):
         return True, "uses hypothesis"


### PR DESCRIPTION
Fixes #56

I'm not sure whether it makes more sense to use `functools.cache` and just not worry about memory overhead. `lru_cache` seemed to be sufficient to speed up the example from sciki-learn in #56.