### PR TITLE
Set switch interval in a loop with increasing numbers

### DIFF
--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -72,8 +72,17 @@ def wrap_function_parallel(fn, n_workers, n_iterations):
         failed = None
         barrier = threading.Barrier(n_workers)
         original_switch = sys.getswitchinterval()
+        new_switch = 1e-6
+        for _ in range(3):
+            try:
+                sys.setswitchinterval(new_switch)
+                break
+            except ValueError:
+                new_switch *= 10
+        else:
+            sys.setswitchinterval(original_switch)
+
         try:
-            sys.setswitchinterval(0.000001)
 
             def closure(*args, **kwargs):
                 for _ in range(n_iterations):


### PR DESCRIPTION
After talking to Pablo and Thomas about this, they suggested that we start at a 1ns switch interval and go up to 100ns for every time setting it fails. After three failures, we go back to original switch interval.

This makes sure that the tests will run in parallel, even if the switch interval is not changed.