### PR TITLE
Support chained attributes in thread unsafe detection

### DIFF
--- a/src/pytest_run_parallel/thread_unsafe_detection.py
+++ b/src/pytest_run_parallel/thread_unsafe_detection.py
@@ -56,47 +56,95 @@ class ThreadUnsafeNodeVisitor(ast.NodeVisitor):
 
         super().__init__()
 
+    def _recursive_analyze_attribute(self, node):
+        current = node
+        while isinstance(current.value, ast.Attribute):
+            current = current.value
+        if not isinstance(current.value, ast.Name):
+            return
+        id = current.value.id
+
+        def _get_child_fn(mod, node):
+            if isinstance(node.value, ast.Attribute):
+                submod = _get_child_fn(mod, node.value)
+                return getattr(submod, node.attr, None)
+
+            if not isinstance(node.value, ast.Name):
+                return None
+            return getattr(mod, node.attr, None)
+
+        if id in getattr(self.fn, "__globals__", {}):
+            mod = self.fn.__globals__[id]
+            child_fn = _get_child_fn(mod, node)
+            if child_fn is not None:
+                self.thread_unsafe, self.thread_unsafe_reason = (
+                    identify_thread_unsafe_nodes(
+                        child_fn, self.skip_set, self.level + 1
+                    )
+                )
+
+    def _build_attribute_chain(self, node):
+        chain = []
+        current = node
+
+        while isinstance(current, ast.Attribute):
+            chain.insert(0, current.attr)
+            current = current.value
+
+        if isinstance(current, ast.Name):
+            chain.insert(0, current.id)
+
+        return chain
+
+    def _visit_attribute_call(self, node):
+        if isinstance(node.value, ast.Name):
+            real_mod = node.value.id
+            if real_mod in self.modules_aliases:
+                real_mod = self.modules_aliases[real_mod]
+            if (real_mod, node.attr) in self.blacklist:
+                self.thread_unsafe = True
+                self.thread_unsafe_reason = (
+                    "calls thread-unsafe function: " f"{real_mod}.{node.attr}"
+                )
+            elif self.level < 2:
+                self._recursive_analyze_attribute(node)
+        elif isinstance(node.value, ast.Attribute):
+            chain = self._build_attribute_chain(node)
+            module_part = ".".join(chain[:-1])
+            func_part = chain[-1]
+            if (module_part, func_part) in self.blacklist:
+                self.thread_unsafe = True
+                self.thread_unsafe_reason = (
+                    f"calls thread-unsafe function: {'.'.join(chain)}"
+                )
+            elif self.level < 2:
+                self._recursive_analyze_attribute(node)
+
+    def _recursive_analyze_name(self, node):
+        if node.id in getattr(self.fn, "__globals__", {}):
+            child_fn = self.fn.__globals__[node.id]
+            self.thread_unsafe, self.thread_unsafe_reason = (
+                identify_thread_unsafe_nodes(child_fn, self.skip_set, self.level + 1)
+            )
+
+    def _visit_name_call(self, node):
+        recurse = True
+        if node.id in self.func_aliases:
+            if self.func_aliases[node.id] in self.blacklist:
+                self.thread_unsafe = True
+                self.thread_unsafe_reason = f"calls thread-unsafe function: {node.id}"
+                recurse = False
+        if recurse and self.level < 2:
+            self._recursive_analyze_name(node)
+
     def visit_Call(self, node):
         if self.thread_unsafe:
             return
 
         if isinstance(node.func, ast.Attribute):
-            if isinstance(node.func.value, ast.Name):
-                real_mod = node.func.value.id
-                if real_mod in self.modules_aliases:
-                    real_mod = self.modules_aliases[real_mod]
-                if (real_mod, node.func.attr) in self.blacklist:
-                    self.thread_unsafe = True
-                    self.thread_unsafe_reason = (
-                        "calls thread-unsafe function: " f"{real_mod}.{node.func.attr}"
-                    )
-                elif self.level < 2:
-                    if node.func.value.id in getattr(self.fn, "__globals__", {}):
-                        mod = self.fn.__globals__[node.func.value.id]
-                        child_fn = getattr(mod, node.func.attr, None)
-                        if child_fn is not None:
-                            self.thread_unsafe, self.thread_unsafe_reason = (
-                                identify_thread_unsafe_nodes(
-                                    child_fn, self.skip_set, self.level + 1
-                                )
-                            )
+            self._visit_attribute_call(node.func)
         elif isinstance(node.func, ast.Name):
-            recurse = True
-            if node.func.id in self.func_aliases:
-                if self.func_aliases[node.func.id] in self.blacklist:
-                    self.thread_unsafe = True
-                    self.thread_unsafe_reason = (
-                        f"calls thread-unsafe function: {node.func.id}"
-                    )
-                    recurse = False
-            if recurse and self.level < 2:
-                if node.func.id in getattr(self.fn, "__globals__", {}):
-                    child_fn = self.fn.__globals__[node.func.id]
-                    self.thread_unsafe, self.thread_unsafe_reason = (
-                        identify_thread_unsafe_nodes(
-                            child_fn, self.skip_set, self.level + 1
-                        )
-                    )
+            self._visit_name_call(node.func)
 
     def visit_Assign(self, node):
         if self.thread_unsafe:


### PR DESCRIPTION
- Correctly detect calls to thread-unsafe functions when the function call comes from a chained attribute with length three or more.
- Do the same for walking down functions in search for assignments to `__thread_unsafe__`.
- Do a minor refactor to make code easier to reason about.

This is the first of a series of PRs aiming to make thread-unsafe detection a bit more stable. The final purpose is to be able to support #73 (disallow stuff at the module level), but going over a few improvements/fixes first, so that that becomes easier to implement.