### PR TITLE
Improvements to thread safety detection and implement disallowing whole modules

### DIFF
--- a/src/pytest_run_parallel/thread_unsafe_detection.py
+++ b/src/pytest_run_parallel/thread_unsafe_detection.py
@@ -131,13 +131,13 @@ class ThreadUnsafeNodeVisitor(ast.NodeVisitor):
                 )
 
     def _visit_name_call(self, node):
-        recurse = True
         if node.id in self.func_aliases:
             if self.func_aliases[node.id] in self.blacklist:
                 self.thread_unsafe = True
                 self.thread_unsafe_reason = f"calls thread-unsafe function: {node.id}"
-                recurse = False
-        if recurse and self.level < 2:
+                return
+
+        if self.level < 2:
             self._recursive_analyze_name(node)
 
     def visit_Call(self, node):
@@ -159,6 +159,7 @@ class ThreadUnsafeNodeVisitor(ast.NodeVisitor):
                     f"calls thread-unsafe function: {self.fn.__name__} "
                     "(inferred via func.__thread_safe__ == False)"
                 )
+                return
 
         self.generic_visit(node)
 

--- a/src/pytest_run_parallel/thread_unsafe_detection.py
+++ b/src/pytest_run_parallel/thread_unsafe_detection.py
@@ -151,10 +151,12 @@ class ThreadUnsafeNodeVisitor(ast.NodeVisitor):
         if len(node.targets) == 1:
             name_node = node.targets[0]
             value_node = node.value
-            if getattr(name_node, "id", None) == "__thread_safe__":
-                self.thread_unsafe = not bool(value_node.value)
+            if getattr(name_node, "id", None) == "__thread_safe__" and not bool(
+                value_node.value
+            ):
+                self.thread_unsafe = True
                 self.thread_unsafe_reason = (
-                    f"calls thread-unsafe function: f{name_node} "
+                    f"calls thread-unsafe function: {self.fn.__name__} "
                     "(inferred via func.__thread_safe__ == False)"
                 )
 

--- a/src/pytest_run_parallel/thread_unsafe_detection.py
+++ b/src/pytest_run_parallel/thread_unsafe_detection.py
@@ -76,7 +76,7 @@ class ThreadUnsafeNodeVisitor(ast.NodeVisitor):
         if id in getattr(self.fn, "__globals__", {}):
             mod = self.fn.__globals__[id]
             child_fn = _get_child_fn(mod, node)
-            if child_fn is not None:
+            if child_fn is not None and inspect.isfunction(child_fn):
                 self.thread_unsafe, self.thread_unsafe_reason = (
                     identify_thread_unsafe_nodes(
                         child_fn, self.skip_set, self.level + 1
@@ -123,9 +123,12 @@ class ThreadUnsafeNodeVisitor(ast.NodeVisitor):
     def _recursive_analyze_name(self, node):
         if node.id in getattr(self.fn, "__globals__", {}):
             child_fn = self.fn.__globals__[node.id]
-            self.thread_unsafe, self.thread_unsafe_reason = (
-                identify_thread_unsafe_nodes(child_fn, self.skip_set, self.level + 1)
-            )
+            if inspect.isfunction(child_fn):
+                self.thread_unsafe, self.thread_unsafe_reason = (
+                    identify_thread_unsafe_nodes(
+                        child_fn, self.skip_set, self.level + 1
+                    )
+                )
 
     def _visit_name_call(self, node):
         recurse = True

--- a/tests/test_thread_unsafe_detection.py
+++ b/tests/test_thread_unsafe_detection.py
@@ -404,3 +404,56 @@ def test_thread_unsafe_function_call_in_assignment(pytester):
             "*::test_thread_unsafe_function_call_in_assignment PASSED*",
         ]
     )
+
+
+def test_thread_unsafe_unittest_mock_patch_object(pytester):
+    pytester.makepyfile("""
+    import sys
+    import unittest.mock
+
+    @unittest.mock.patch.object(sys, "platform", "VAX")
+    def test_thread_unsafe_unittest_mock_patch_object(num_parallel_threads):
+        assert sys.platform == "VAX"
+        assert num_parallel_threads == 1
+    """)
+
+    result = pytester.runpytest("--parallel-threads=10", "-v")
+    result.stdout.fnmatch_lines(
+        [
+            "*::test_thread_unsafe_unittest_mock_patch_object PASSED*",
+        ]
+    )
+
+
+def test_thread_unsafe_ctypes(pytester):
+    pytester.makepyfile("""
+    import ctypes.util
+
+    def test_thread_unsafe_ctypes(num_parallel_threads):
+        ctypes.util.find_library("m")
+        assert num_parallel_threads == 1
+    """)
+
+    result = pytester.runpytest("--parallel-threads=10", "-v")
+    result.stdout.fnmatch_lines(
+        [
+            "*::test_thread_unsafe_ctypes PASSED*",
+        ]
+    )
+
+
+def test_thread_unsafe_ctypes_import_from(pytester):
+    pytester.makepyfile("""
+    from ctypes.util import find_library
+
+    def test_thread_unsafe_ctypes(num_parallel_threads):
+        find_library("m")
+        assert num_parallel_threads == 1
+    """)
+
+    result = pytester.runpytest("--parallel-threads=10", "-v")
+    result.stdout.fnmatch_lines(
+        [
+            "*::test_thread_unsafe_ctypes PASSED*",
+        ]
+    )

--- a/tests/test_thread_unsafe_detection.py
+++ b/tests/test_thread_unsafe_detection.py
@@ -367,3 +367,40 @@ def test_chained_attribute_thread_safe_assignment(pytester):
             "*::test_chained_attribute_thread_safe_assignment PASSED*",
         ]
     )
+
+
+def test_wrapped_function_call(pytester):
+    pytester.makepyfile("""
+    import pytest
+
+    def wrapper(x):
+        return x
+
+    def test_wrapped_function_call(num_parallel_threads):
+        wrapper(pytest.warns())
+        assert num_parallel_threads == 1
+    """)
+
+    result = pytester.runpytest("--parallel-threads=10", "-v")
+    result.stdout.fnmatch_lines(
+        [
+            "*::test_wrapped_function_call PASSED*",
+        ]
+    )
+
+
+def test_thread_unsafe_function_call_in_assignment(pytester):
+    pytester.makepyfile("""
+    import pytest
+
+    def test_thread_unsafe_function_call_in_assignment(num_parallel_threads):
+        x = y = pytest.warns()
+        assert num_parallel_threads == 1
+    """)
+
+    result = pytester.runpytest("--parallel-threads=10", "-v")
+    result.stdout.fnmatch_lines(
+        [
+            "*::test_thread_unsafe_function_call_in_assignment PASSED*",
+        ]
+    )


### PR DESCRIPTION
This includes a few things:
- General improvements to thread safety detection like:
	- Call `generic_visit` in all paths and bail out early when already thread unsafe
	- Do not recurse when target is not a function
	- Fix message printed in error report when unsafety is detected because of `__thread_safe__`
- Add ability to blocklist whole modules and do that for `ctypes` and `unittest.mock`

It's easier to review this commit by commit.

Also, here's the test results for `scipy` and `scikit-learn` when it comes to collection performance:

**SciPy**:

|  | Collection time | Collected items to run in parallel |
| --- | --- | --- |
| main   | 33.92s             | 53101 |
| HEAD | 38.19s             | 53089 |

**scikit-learn**:

|  | Collection time | Collected items to run in parallel |
| --- | --- | --- |
| main   | 11.40s             | 23049 |
| HEAD | 10.46s             | 35600 |
