### PR TITLE
Fail test suite when GIL is enabled dynamically at runtime

### DIFF
--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -121,13 +121,6 @@ class RunParallelPlugin:
         self.thread_unsafe = {}
         self.run_in_parallel = {}
 
-        self.gil_initially_disabled = not self._is_gil_enabled()
-
-    def _is_gil_enabled(self):
-        if hasattr(sys, "_is_gil_enabled"):
-            return sys._is_gil_enabled()
-        return True
-
     def skipped_or_not_parallel(self, *, plural):
         if plural:
             skipped = "were skipped"

--- a/uv.lock
+++ b/uv.lock
@@ -285,7 +285,7 @@ wheels = [
 
 [[package]]
 name = "pytest-run-parallel"
-version = "0.4.5.dev0"
+version = "0.5.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "pytest" },


### PR DESCRIPTION
@ngoldbaum We can get this into 0.6 as well.

Only problem is I don't really know how to test this. I checked manually with a custom package with a compiled extension and the test suite indeed failed.