### PR TITLE
Add native extension that gets built and imported during tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dev = [
     "pytest-cov>=5.0.0",
     "pytest-order>=1.3.0",
     "ruff>=0.7.2",
+    "setuptools>=80.9.0",
     "tox>=4.23.2",
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,71 @@
+import functools
+import glob
+import os
+import shutil
+import subprocess
+import sys
+import sysconfig
+from pathlib import Path
+
+import pytest
+
 pytest_plugins = "pytester"
+
+TESTPKG_DIR = Path(__file__).parent / "testpkg"
+
+
+def call_once(func):
+    func._called_with_args = set()
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        if (args, kwargs) in func._called_with_args:
+            return
+        func._called_with_args.add((args, kwargs))
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+@call_once
+def build_gil_test_extension(gil_enable):
+    """Build the gil_test extension module for testing."""
+
+    env = os.environ.copy()
+    cmd = [sys.executable, "setup.py", "build_ext", "-i"]
+    if gil_enable:
+        cmd.append("--enable-gil")
+
+    result = subprocess.run(
+        cmd, cwd=TESTPKG_DIR, env=env, capture_output=True, text=True
+    )
+
+    if result.returncode != 0:
+        raise RuntimeError(f"Failed to build extension: {result.stderr}")
+
+
+def pytester_with_module(pytester: pytest.Pytester, *, enable_gil):
+    if not bool(sysconfig.get_config_var("Py_GIL_DISABLED")):
+        pytest.skip(
+            "gil enabling functionality only needs to be tested on the free-threaded build"
+        )
+
+    path = f"{TESTPKG_DIR!s}/{'gil_enable' if enable_gil else 'gil_disable'}*.so"
+    for file in glob.glob(path):
+        shutil.copy(file, pytester.path)
+
+    # Needed cause otherwise the GIL will only be enabled once
+    old_method = pytester._method
+    pytester._method = "subprocess"
+    yield pytester
+    pytester._method = old_method
+
+
+@pytest.fixture()
+def pytester_with_gil_enabled_module(pytester):
+    yield from pytester_with_module(pytester, enable_gil=True)
+
+
+@pytest.fixture()
+def pytester_with_gil_disabled_module(pytester):
+    yield from pytester_with_module(pytester, enable_gil=False)

--- a/tests/testpkg/README.md
+++ b/tests/testpkg/README.md
@@ -1,0 +1,22 @@
+# GIL Enabler Test Extension
+
+This directory contains a C extension module used for testing GIL detection functionality.
+
+## Purpose
+
+The `gil_[enable|disable]` extension module is designed to trigger actual GIL enabling behavior in
+free-threaded Python builds, replacing the previous approach that used `warnings.warn()`
+to simulate the warning message.
+
+## Building
+
+To build the extension in-place for testing:
+
+```bash
+python setup.py build_ext -i
+```
+
+## Usage in Tests
+
+The extension module is built and imported in the test files to trigger actual GIL enabling
+behavior, which allows for more realistic testing of the GIL detection feature.

--- a/tests/testpkg/gil_test.c
+++ b/tests/testpkg/gil_test.c
@@ -1,0 +1,56 @@
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+/* This extension module can be built in two modes:
+ * 1. Default: properly configured to not require the GIL
+ *    and should not trigger GIL enabling behavior.
+ * 2. With ENABLE_GIL defined: triggers GIL enabling behavior
+ *    in free-threaded builds by not using the Py_mod_gil slot.
+ */
+
+static PyObject *
+test_function(PyObject *self, PyObject *args)
+{
+    /* This function doesn't do anything special. The difference is in
+     * how the module is configured regarding GIL requirements.
+     */
+    Py_RETURN_NONE;
+}
+
+static PyMethodDef gil_test_methods[] = {
+    {"test_function", test_function, METH_NOARGS, "Test function"},
+    {NULL, NULL, 0, NULL}
+};
+
+static PyModuleDef_Slot gil_test_slots[] = {
+#ifndef ENABLE_GIL
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+#endif
+    {0, NULL}
+};
+
+static struct PyModuleDef gil_test_module = {
+    PyModuleDef_HEAD_INIT,
+#ifndef ENABLE_GIL
+    "gil_disable",
+#else
+    "gil_enable",
+#endif
+    NULL,
+    0,
+    gil_test_methods,
+    gil_test_slots,
+    NULL,
+    NULL,
+    NULL
+};
+
+PyMODINIT_FUNC
+#ifndef ENABLE_GIL
+PyInit_gil_disable(void)
+#else
+PyInit_gil_enable(void)
+#endif
+{
+    return PyModuleDef_Init(&gil_test_module);
+}

--- a/tests/testpkg/setup.py
+++ b/tests/testpkg/setup.py
@@ -1,0 +1,22 @@
+import sys
+
+from setuptools import Extension, setup
+
+enable_gil = "--enable-gil" in sys.argv
+if enable_gil:
+    sys.argv.remove("--enable-gil")
+
+define_macros = []
+if enable_gil:
+    define_macros.append(("ENABLE_GIL", "1"))
+
+gil_test_extension = Extension(
+    "gil_enable" if enable_gil else "gil_disable",
+    sources=["gil_test.c"],
+    define_macros=define_macros,
+)
+
+setup(
+    name="gil_test",
+    ext_modules=[gil_test_extension],
+)

--- a/uv.lock
+++ b/uv.lock
@@ -302,6 +302,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-order" },
     { name = "ruff" },
+    { name = "setuptools" },
     { name = "tox" },
 ]
 
@@ -318,6 +319,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=5.0.0" },
     { name = "pytest-order", specifier = ">=1.3.0" },
     { name = "ruff", specifier = ">=0.7.2" },
+    { name = "setuptools", specifier = ">=80.9.0" },
     { name = "tox", specifier = ">=4.23.2" },
 ]
 
@@ -397,6 +399,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a1/16/8969304f25bcd0e4af1778342e63b715e91db8a2dbb51807acd858cba915/ruff-0.7.2-py3-none-win32.whl", hash = "sha256:fa993cfc9f0ff11187e82de874dfc3611df80852540331bc85c75809c93253a8", size = 8650268, upload-time = "2024-11-01T15:07:19.755Z" },
     { url = "https://files.pythonhosted.org/packages/d9/18/c4b00d161def43fe5968e959039c8f6ce60dca762cec4a34e4e83a4210a0/ruff-0.7.2-py3-none-win_amd64.whl", hash = "sha256:dd8800cbe0254e06b8fec585e97554047fb82c894973f7ff18558eee33d1cb88", size = 9433693, upload-time = "2024-11-01T15:07:22.513Z" },
     { url = "https://files.pythonhosted.org/packages/7f/7b/c920673ac01c19814dd15fc617c02301c522f3d6812ca2024f4588ed4549/ruff-0.7.2-py3-none-win_arm64.whl", hash = "sha256:bb8368cd45bba3f57bb29cbb8d64b4a33f8415d0149d2655c5c8539452ce7760", size = 8735845, upload-time = "2024-11-01T15:07:24.629Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "80.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c", size = 1319958, upload-time = "2025-05-27T00:56:51.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922", size = 1201486, upload-time = "2025-05-27T00:56:49.664Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This allows us to test the GIL enabling functionality with an actual compiled extension rather than the hack with warnings.warn.

@ngoldbaum What do you think about something like this?