### PR TITLE
Fix tox coverage reporting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,9 +79,8 @@ commands = [
     [
     "pytest",
     "-v",
-    "--cov-report", "lcov",
-    "--cov", "src/pytest_run_parallel",
-    "--cov", "tests",
+    "--cov-report", "term",
+    "--cov=pytest_run_parallel", "--cov=tests",
     "{posargs:tests}"
     ],
     [


### PR DESCRIPTION
Before:

```
=================================================================== tests coverage ====================================================================
________________________________________________ coverage: platform darwin, python 3.14.0-candidate-1 _________________________________________________

Coverage LCOV written to file coverage.lcov
```

With this PR:

```
=================================================================== tests coverage ====================================================================
________________________________________________ coverage: platform darwin, python 3.14.0-candidate-1 _________________________________________________

Name                                                                                       Stmts   Miss  Cover
--------------------------------------------------------------------------------------------------------------
.tox/py314t/lib/python3.14t/site-packages/pytest_run_parallel/__init__.py                      0      0   100%
.tox/py314t/lib/python3.14t/site-packages/pytest_run_parallel/cpu_detection.py                29     14    52%
.tox/py314t/lib/python3.14t/site-packages/pytest_run_parallel/plugin.py                      211     47    78%
.tox/py314t/lib/python3.14t/site-packages/pytest_run_parallel/thread_comparator.py            52     14    73%
.tox/py314t/lib/python3.14t/site-packages/pytest_run_parallel/thread_unsafe_detection.py     187     41    78%
.tox/py314t/lib/python3.14t/site-packages/pytest_run_parallel/utils.py                        24      6    75%
tests/conftest.py                                                                              1      0   100%
tests/test_cpu_detection.py                                                                   61     26    57%
tests/test_run_parallel.py                                                                   119      2    98%
tests/test_thread_comparator.py                                                                4      0   100%
tests/test_thread_unsafe_detection.py                                                        116      4    97%
--------------------------------------------------------------------------------------------------------------
TOTAL                                                                                        804    154    81%
```

Seems a lot nicer! Also the way it's currently configured will only get the coverage for the plugin implementation correct for an editable install. With this change it'll always be correct for all installs.