### PR TITLE
Fix typo in option help

### DIFF
--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -350,7 +350,7 @@ def pytest_addoption(parser):
         dest="iterations",
         default=1,
         type=int,
-        help="Set the number of threads used to execute each test concurrently.",
+        help="Set the number of iterations that each thread will run.",
     )
     parser.addoption(
         "--skip-thread-unsafe",


### PR DESCRIPTION
There's a typo here, as iterations does not control number of threads.

```
$ pytest --help

...

run-parallel:
  --parallel-threads=PARALLEL_THREADS
                        Set the number of threads used to execute each test concurrently.
  --iterations=ITERATIONS
                        Set the number of threads used to execute each test concurrently.
```