### PR TITLE
Move options to common group, and add help text for options

### DIFF
--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -343,7 +343,8 @@ def pytest_addoption(parser):
         action="store",
         dest="parallel_threads",
         default=1,
-        help="Set the number of threads used to execute each test concurrently. (default: %(default)s)",
+        help="Set the number of threads used to execute each test concurrently. (default: "
+        "%(default)s)",
     )
     group.addoption(
         "--iterations",
@@ -357,7 +358,8 @@ def pytest_addoption(parser):
         "--skip-thread-unsafe",
         action="store",
         dest="skip_thread_unsafe",
-        help="Skip running thread-unsafe tests. If not provided, thread-unsafe tests will still run, but only in one thread.",
+        help="Skip running thread-unsafe tests. If not provided, thread-unsafe tests will still "
+        "run, but only in one thread.",
         type=bool,
         default=False,
     )
@@ -366,24 +368,33 @@ def pytest_addoption(parser):
         action="store_true",
         dest="mark_warnings_as_unsafe",
         default=False,
+        help="Mark warnings capture, such as pytest.warns(), as thread-unsafe. If not provided, "
+        "the thread safety of warnings capture will be determined automatically.",
     )
     group.addoption(
         "--mark-ctypes-as-unsafe",
         action="store_true",
         dest="mark_ctypes_as_unsafe",
         default=False,
+        help="Mark all uses of ctypes as thread-unsafe. If not provided, the thread safety of "
+        "ctypes (but not the underlying C code) will be determined automatically.",
     )
     group.addoption(
         "--mark-hypothesis-as-unsafe",
         action="store_true",
         dest="mark_hypothesis_as_unsafe",
         default=False,
+        help="Mark hypothesis as thread-unsafe. If not provided, the thread safety of hypothesis "
+        "will be determined automatically.",
     )
     group.addoption(
         "--ignore-gil-enabled",
         action="store_true",
         dest="ignore_gil_enabled",
         default=False,
+        help="Ignore the GIL becoming enabled in the middle of a test. By default, if the GIL is "
+        "re-enabled at runtime, pytest will exit with a non-zero exit code. This option has no "
+        "effect for non-free-threaded builds.",
     )
     parser.addini(
         "thread_unsafe_fixtures",

--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -343,7 +343,7 @@ def pytest_addoption(parser):
         action="store",
         dest="parallel_threads",
         default=1,
-        help="Set the number of threads used to execute each test concurrently.",
+        help="Set the number of threads used to execute each test concurrently. (default: %(default)s)",
     )
     group.addoption(
         "--iterations",
@@ -351,13 +351,13 @@ def pytest_addoption(parser):
         dest="iterations",
         default=1,
         type=int,
-        help="Set the number of iterations that each thread will run.",
+        help="Set the number of iterations that each thread will run. (default: %(default)s)",
     )
     group.addoption(
         "--skip-thread-unsafe",
         action="store",
         dest="skip_thread_unsafe",
-        help="Whether to skip running thread-unsafe tests",
+        help="Skip running thread-unsafe tests. If not provided, thread-unsafe tests will still run, but only in one thread.",
         type=bool,
         default=False,
     )

--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -336,6 +336,7 @@ def pytest_configure(config):
 
 
 def pytest_addoption(parser):
+    # Note: new options should be on group, not parser
     group = parser.getgroup("run-parallel")
     group.addoption(
         "--parallel-threads",
@@ -352,7 +353,7 @@ def pytest_addoption(parser):
         type=int,
         help="Set the number of iterations that each thread will run.",
     )
-    parser.addoption(
+    group.addoption(
         "--skip-thread-unsafe",
         action="store",
         dest="skip_thread_unsafe",
@@ -360,25 +361,25 @@ def pytest_addoption(parser):
         type=bool,
         default=False,
     )
-    parser.addoption(
+    group.addoption(
         "--mark-warnings-as-unsafe",
         action="store_true",
         dest="mark_warnings_as_unsafe",
         default=False,
     )
-    parser.addoption(
+    group.addoption(
         "--mark-ctypes-as-unsafe",
         action="store_true",
         dest="mark_ctypes_as_unsafe",
         default=False,
     )
-    parser.addoption(
+    group.addoption(
         "--mark-hypothesis-as-unsafe",
         action="store_true",
         dest="mark_hypothesis_as_unsafe",
         default=False,
     )
-    parser.addoption(
+    group.addoption(
         "--ignore-gil-enabled",
         action="store_true",
         dest="ignore_gil_enabled",

--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -358,8 +358,8 @@ def pytest_addoption(parser):
         "--skip-thread-unsafe",
         action="store",
         dest="skip_thread_unsafe",
-        help="Skip running thread-unsafe tests. If not provided, thread-unsafe tests will still "
-        "run, but only in one thread.",
+        help="Whether to skip running thread-unsafe tests. If not provided, thread-unsafe tests "
+        "will still run, but only in one thread.",
         type=bool,
         default=False,
     )


### PR DESCRIPTION
This PR aims to improve two things.

First, currently some options are in a dedicated 'run-parallel' section, but other options are in the 'Custom options' section. This seems confusing.

```
run-parallel:
  --parallel-threads=PARALLEL_THREADS
                        Set the number of threads used to execute each test concurrently.
  --iterations=ITERATIONS
                        Set the number of iterations that each thread will run.

Custom options:
  --skip-thread-unsafe=SKIP_THREAD_UNSAFE
                        Whether to skip running thread-unsafe tests
  --mark-warnings-as-unsafe
  --mark-ctypes-as-unsafe
  --mark-hypothesis-as-unsafe
  --ignore-gil-enabled
  --lsof                Run FD checks if lsof is available
  --runpytest={inprocess,subprocess}
                        Run pytest sub runs in tests using an 'inprocess' or 'subprocess' (python -m main) method
```

This can be improved by moving all of the options to the same group.

Second, some options could use help text to describe what they do. I also added documentation about the default behavior, in cases where it wasn't obvious.

- For `--skip-thread-unsafe`: I tried to clarify that the the alternative to skipping thread unsafe tests is running them in a single thread, not ignoring the thread safety problem.
- For `--mark-warnings-as-unsafe`: a user might think that if they don't pass this option, then warnings will not be marked as unsafe. However, this is not true. Also, I tried to clarify that the thing it reacts to is not warnings, per se, but warnings capture.
- For `--mark-ctypes-as-unsafe`: I added a similar note, but was worried it might imply that we check the C code that ctypes is calling as being thread-safe, which we don't, so I added the text "(but not the underlying C code)"
- For `--ignore-gil-enabled`: I added a note about what exactly this option protects against. I tried to emphasize that users who are running GIL enabled builds don't need to enable this option.

Here is the rendered revised help:

```
run-parallel:
  --parallel-threads=PARALLEL_THREADS
                        Set the number of threads used to execute each test
                        concurrently. (default: 1)
  --iterations=ITERATIONS
                        Set the number of iterations that each thread will run.
                        (default: 1)
  --skip-thread-unsafe=SKIP_THREAD_UNSAFE
                        Whether to skip running thread-unsafe tests. If not
                        provided, thread-unsafe tests will still run, but only in
                        one thread.
  --mark-warnings-as-unsafe
                        Mark warnings capture, such as pytest.warns(), as thread-
                        unsafe. If not provided, the thread safety of warnings
                        capture will be determined automatically.
  --mark-ctypes-as-unsafe
                        Mark all uses of ctypes as thread-unsafe. If not
                        provided, the thread safety of ctypes (but not the
                        underlying C code) will be determined automatically.
  --mark-hypothesis-as-unsafe
                        Mark hypothesis as thread-unsafe. If not provided, the
                        thread safety of hypothesis will be determined
                        automatically.
  --ignore-gil-enabled  Ignore the GIL becoming enabled in the middle of a test.
                        By default, if the GIL is re-enabled at runtime, pytest
                        will exit with a non-zero exit code. This option has no
                        effect for non-free-threaded builds.
```