### PR TITLE
Create thread_id and iteration_id fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ tests to display different behavior between threads and iterations.
 import numpy as np
 
 def test_unique_rng_streams(thread_index):
-    # create an RNG stream with a seed that is deterministic 
+    # create an RNG stream with a seed that is deterministic
     # but still unique to this thread
     rng = np.random.default_rng(thread_index)
     ...

--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -58,7 +58,7 @@ def wrap_function_parallel(fn, n_workers, n_iterations):
                 thread_index, args = args[0], args[1:]
                 if "thread_index" in kwargs:
                     kwargs["thread_index"] = thread_index
-                
+
                 for i in range(n_iterations):
                     if "iteration_index" in kwargs:
                         kwargs["iteration_index"] = i
@@ -81,7 +81,9 @@ def wrap_function_parallel(fn, n_workers, n_iterations):
                 worker_kwargs = kwargs
                 # "smuggling" i into closure with args to use for thread_index fixture
                 workers.append(
-                    threading.Thread(target=closure, args=(i, *args), kwargs=worker_kwargs)
+                    threading.Thread(
+                        target=closure, args=(i, *args), kwargs=worker_kwargs
+                    )
                 )
 
             num_completed = 0

--- a/tests/test_thread_index.py
+++ b/tests/test_thread_index.py
@@ -80,7 +80,9 @@ def test_iteration_index_multi_iteration(pytester: pytest.Pytester) -> None:
     )
 
 
-def test_iteration_index_multi_iteration_mutli_thread(pytester: pytest.Pytester) -> None:
+def test_iteration_index_multi_iteration_mutli_thread(
+    pytester: pytest.Pytester,
+) -> None:
     pytester.makepyfile("""
         def test_iteration_index(iteration_index, num_iterations):
             assert iteration_index < num_iterations


### PR DESCRIPTION
Some tests have issues with parallelism and repetition (such as seen here #109 ) that would benefit from having access to a unique identifier between threads/iterations. A potential work around this issue is utilizing randomly generated ids, but pytest-run-parallel would benefit from having something like this built in.

I am suggesting two new fixtures: `thread_id` and `iteration_id`. Both are ints that start at 0 and go up for each thread/iteration. 

The test from #109 can then be rewritten with the fixtures as so:

```python
def test_with_tmp_path(tmp_path, thread_id, iteration_id):
    path = tmp_path / str(thread_id) / str(iteration_id)
    path.mkdir(parents=True)
    assert path.exists()
    assert path.is_dir()
    assert len(list(path .iterdir())) == 0
    d = path / "sub"
    assert not d.exists()
    d.mkdir()
    assert d.exists()
```

These fixtures should also be useful within pytest-run-parallel. I hope to create another fixture that will be a built-in thread-safe alternative to tmp_path that will utilize these to ensure the creation of unique directories between threads.