### PR TITLE
Patch tmp_path/tmpdir to be thread-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,12 +90,16 @@ those fixtures are shared between threads.
     - `pytest.mark.iterations(n)` to mark a single test to run `n`
         times in each thread
 
-- And the corresponding fixtures:
+- Four corresponding fixtures:
     - `num_parallel_threads`: The number of threads the test will run in
     - `num_iterations`: The number of iterations the test will run in
         each thread
     - `thread_index`: An index for the test's current thread.
     - `iteration_index`: An index for the test's current iteration.
+
+- Modifications to existing fixtures:
+    - `tmp_path` and `tmpdir`: Patched to be thread-safe, with individual
+        subdirectories being created for each thread and iteration.
 
 **Note**: It's possible to specify `--parallel-threads=auto` or
 `pytest.mark.parallel_threads("auto")` which will let

--- a/README.md
+++ b/README.md
@@ -99,7 +99,9 @@ those fixtures are shared between threads.
 
 - Modifications to existing fixtures:
     - `tmp_path` and `tmpdir`: Patched to be thread-safe, with individual
-        subdirectories being created for each thread and iteration.
+    subdirectories being created for each thread. Subdirectories are not
+    created for each iteration, so you may see issues with reused temporary
+    directions when using `--iterations`.
 
 **Note**: It's possible to specify `--parallel-threads=auto` or
 `pytest.mark.parallel_threads("auto")` which will let

--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -56,8 +56,6 @@ def wrap_function_parallel(fn, n_workers, n_iterations):
             def closure(*args, **kwargs):
                 # "smuggling" thread_index into closure with args
                 thread_index, args = args[0], args[1:]
-                thread_tmp_path = None
-                thread_tmpdir = None
                 # modifying fixtures
                 if n_workers > 1:
                     if "thread_index" in kwargs:
@@ -67,29 +65,14 @@ def wrap_function_parallel(fn, n_workers, n_iterations):
                             kwargs["tmp_path"] / f"thread_{thread_index!s}"
                         )
                         kwargs["tmp_path"].mkdir()
-                        thread_tmp_path = kwargs["tmp_path"]
                     if "tmpdir" in kwargs:
                         kwargs["tmpdir"] = kwargs["tmpdir"].mkdir(
                             f"thread_{thread_index!s}"
                         )
-                        thread_tmpdir = kwargs["tmpdir"]
-
-                if n_iterations > 1:
-                    if "tmp_path" in kwargs:
-                        for i in range(n_iterations):
-                            (thread_tmp_path / f"iteration_{i!s}").mkdir()
-                    if "tmpdir" in kwargs:
-                        for i in range(n_iterations):
-                            thread_tmpdir.mkdir(f"iteration_{i!s}")
 
                 for i in range(n_iterations):
-                    if n_iterations > 1:
-                        if "iteration_index" in kwargs:
-                            kwargs["iteration_index"] = i
-                        if "tmp_path" in kwargs:
-                            kwargs["tmp_path"] = thread_tmp_path / f"iteration_{i!s}"
-                        if "tmpdir" in kwargs:
-                            kwargs["tmpdir"] = thread_tmpdir.join(f"iteration_{i!s}")
+                    if "iteration_index" in kwargs:
+                        kwargs["iteration_index"] = i
 
                     barrier.wait()
                     try:

--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -64,10 +64,10 @@ def wrap_function_parallel(fn, n_workers, n_iterations):
                         kwargs["tmp_path"] = (
                             kwargs["tmp_path"] / f"thread_{thread_index!s}"
                         )
-                        kwargs["tmp_path"].mkdir()
+                        kwargs["tmp_path"].mkdir(exist_ok=True)
                     if "tmpdir" in kwargs:
-                        kwargs["tmpdir"] = kwargs["tmpdir"].mkdir(
-                            f"thread_{thread_index!s}"
+                        kwargs["tmpdir"] = kwargs["tmpdir"].ensure(
+                            f"thread_{thread_index!s}", dir=True
                         )
 
                 for i in range(n_iterations):

--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -56,10 +56,40 @@ def wrap_function_parallel(fn, n_workers, n_iterations):
             def closure(*args, **kwargs):
                 # "smuggling" thread_index into closure with args
                 thread_index, args = args[0], args[1:]
-                wrap_setup_thread(args, kwargs, thread_index, n_workers)
+                thread_tmp_path = None
+                thread_tmpdir = None
+                # modifying fixtures
+                if n_workers > 1:
+                    if "thread_index" in kwargs:
+                        kwargs["thread_index"] = thread_index
+                    if "tmp_path" in kwargs:
+                        kwargs["tmp_path"] = (
+                            kwargs["tmp_path"] / f"thread_{thread_index!s}"
+                        )
+                        kwargs["tmp_path"].mkdir()
+                        thread_tmp_path = kwargs["tmp_path"]
+                    if "tmpdir" in kwargs:
+                        kwargs["tmpdir"] = kwargs["tmpdir"].mkdir(
+                            f"thread_{thread_index!s}"
+                        )
+                        thread_tmpdir = kwargs["tmpdir"]
+
+                if n_iterations > 1:
+                    if "tmp_path" in kwargs:
+                        for i in range(n_iterations):
+                            (thread_tmp_path / f"iteration_{i!s}").mkdir()
+                    if "tmpdir" in kwargs:
+                        for i in range(n_iterations):
+                            thread_tmpdir.mkdir(f"iteration_{i!s}")
 
                 for i in range(n_iterations):
-                    wrap_setup_iteration(args, kwargs, i, n_iterations)
+                    if n_iterations > 1:
+                        if "iteration_index" in kwargs:
+                            kwargs["iteration_index"] = i
+                        if "tmp_path" in kwargs:
+                            kwargs["tmp_path"] = thread_tmp_path / f"iteration_{i!s}"
+                        if "tmpdir" in kwargs:
+                            kwargs["tmpdir"] = thread_tmpdir.join(f"iteration_{i!s}")
 
                     barrier.wait()
                     try:
@@ -110,28 +140,6 @@ def wrap_function_parallel(fn, n_workers, n_iterations):
             raise errors[0]
 
     return inner
-
-
-def wrap_setup_thread(args, kwargs, thread_index, n_workers):
-    # modifies fixtures if needed for each thread
-    # thread_index: passes in thread index
-    # tmp_path: creates and sets to subdirectories for each thread
-    # tmpdir: creates and sets to subdirectories for each thread
-    if n_workers > 1:
-        if "thread_index" in kwargs:
-            kwargs["thread_index"] = thread_index
-        if "tmp_path" in kwargs:
-            kwargs["tmp_path"] = kwargs["tmp_path"] / f"thread_{thread_index!s}"
-            kwargs["tmp_path"].mkdir()
-        if "tmpdir" in kwargs:
-            kwargs["tmpdir"] = kwargs["tmpdir"].mkdir(f"thread_{thread_index!s}")
-
-
-def wrap_setup_iteration(args, kwargs, index, n_iterations):
-    # modifies fixtures if needed for each iteration
-    # iteration_index: passes in iteration index
-    if "iteration_index" in kwargs:
-        kwargs["iteration_index"] = index
 
 
 class RunParallelPlugin:

--- a/tests/test_tmp_path.py
+++ b/tests/test_tmp_path.py
@@ -147,7 +147,7 @@ def test_tmpdir_delete(pytester: pytest.Pytester, parallel, passing):
 
 @pytest.mark.parametrize("parallel, passing", parallel_threads)
 def test_tmp_path_tmpdir(pytester: pytest.Pytester, parallel, passing):
-    # ensures we can delete files in each tmpdir
+    # ensures tmp_path and tmpdir can be used at the same time
     pytester.makepyfile("""
         def test_both(tmp_path, tmpdir):
             pass

--- a/tests/test_tmp_path.py
+++ b/tests/test_tmp_path.py
@@ -1,15 +1,13 @@
 import pytest
 
 parallel_threads = [
-    (1, 1, "PASSED"),  # no parallel threads
-    (1, 4, "PASSED"),  # no parallel threads
-    ("auto", 1, "PARALLEL PASSED"),  # parallel threads
-    ("auto", 4, "PARALLEL PASSED"),  # parallel threads
+    (1, "PASSED"),  # no parallel threads
+    ("auto", "PARALLEL PASSED"),  # parallel threads
 ]
 
 
-@pytest.mark.parametrize("parallel, it, passing", parallel_threads)
-def test_tmp_path_is_empty(pytester: pytest.Pytester, parallel, it, passing):
+@pytest.mark.parametrize("parallel, passing", parallel_threads)
+def test_tmp_path_is_empty(pytester: pytest.Pytester, parallel, passing):
     # ensures tmp_path is empty for each thread
     # test from (gh-109)
     pytester.makepyfile("""
@@ -24,9 +22,7 @@ def test_tmp_path_is_empty(pytester: pytest.Pytester, parallel, it, passing):
             assert d.exists()
     """)
 
-    result = pytester.runpytest(
-        f"--parallel-threads={parallel}", f"--iterations={it}", "-v"
-    )
+    result = pytester.runpytest(f"--parallel-threads={parallel}", "-v")
 
     result.stdout.fnmatch_lines(
         [
@@ -35,8 +31,8 @@ def test_tmp_path_is_empty(pytester: pytest.Pytester, parallel, it, passing):
     )
 
 
-@pytest.mark.parametrize("parallel, it, passing", parallel_threads)
-def test_tmp_path_read_write(pytester: pytest.Pytester, parallel, it, passing):
+@pytest.mark.parametrize("parallel, passing", parallel_threads)
+def test_tmp_path_read_write(pytester: pytest.Pytester, parallel, passing):
     # ensures we can read/write in each tmp_path
     pytester.makepyfile("""
         def test_tmp_path(tmp_path):
@@ -47,9 +43,7 @@ def test_tmp_path_read_write(pytester: pytest.Pytester, parallel, it, passing):
             assert file.read_text() == "Hello world!"
     """)
 
-    result = pytester.runpytest(
-        f"--parallel-threads={parallel}", f"--iterations={it}", "-v"
-    )
+    result = pytester.runpytest(f"--parallel-threads={parallel}", "-v")
 
     result.stdout.fnmatch_lines(
         [
@@ -58,8 +52,8 @@ def test_tmp_path_read_write(pytester: pytest.Pytester, parallel, it, passing):
     )
 
 
-@pytest.mark.parametrize("parallel, it, passing", parallel_threads)
-def test_tmp_path_delete(pytester: pytest.Pytester, parallel, it, passing):
+@pytest.mark.parametrize("parallel, passing", parallel_threads)
+def test_tmp_path_delete(pytester: pytest.Pytester, parallel, passing):
     # ensures we can delete files in each tmp_path
     pytester.makepyfile("""
         def test_tmp_path(tmp_path):
@@ -75,9 +69,7 @@ def test_tmp_path_delete(pytester: pytest.Pytester, parallel, it, passing):
             assert not subdir.exists()
     """)
 
-    result = pytester.runpytest(
-        f"--parallel-threads={parallel}", f"--iterations={it}", "-v"
-    )
+    result = pytester.runpytest(f"--parallel-threads={parallel}", "-v")
 
     result.stdout.fnmatch_lines(
         [
@@ -86,8 +78,8 @@ def test_tmp_path_delete(pytester: pytest.Pytester, parallel, it, passing):
     )
 
 
-@pytest.mark.parametrize("parallel, it, passing", parallel_threads)
-def test_tmpdir_is_empty(pytester: pytest.Pytester, parallel, it, passing):
+@pytest.mark.parametrize("parallel, passing", parallel_threads)
+def test_tmpdir_is_empty(pytester: pytest.Pytester, parallel, passing):
     # ensures tmpdir is empty for each thread
     pytester.makepyfile("""
         def test_tmpdir(tmpdir):
@@ -98,9 +90,7 @@ def test_tmpdir_is_empty(pytester: pytest.Pytester, parallel, it, passing):
             assert tmpdir.mkdir("sub").check()
     """)
 
-    result = pytester.runpytest(
-        f"--parallel-threads={parallel}", f"--iterations={it}", "-v"
-    )
+    result = pytester.runpytest(f"--parallel-threads={parallel}", "-v")
 
     result.stdout.fnmatch_lines(
         [
@@ -109,8 +99,8 @@ def test_tmpdir_is_empty(pytester: pytest.Pytester, parallel, it, passing):
     )
 
 
-@pytest.mark.parametrize("parallel, it, passing", parallel_threads)
-def test_tmpdir_read_write(pytester: pytest.Pytester, parallel, it, passing):
+@pytest.mark.parametrize("parallel, passing", parallel_threads)
+def test_tmpdir_read_write(pytester: pytest.Pytester, parallel, passing):
     # ensures we can read/write in each tmpdir
     pytester.makepyfile("""
         def test_tmpdir(tmpdir):
@@ -121,9 +111,7 @@ def test_tmpdir_read_write(pytester: pytest.Pytester, parallel, it, passing):
             assert file.read_text("utf-8") == "Hello world!"
     """)
 
-    result = pytester.runpytest(
-        f"--parallel-threads={parallel}", f"--iterations={it}", "-v"
-    )
+    result = pytester.runpytest(f"--parallel-threads={parallel}", "-v")
 
     result.stdout.fnmatch_lines(
         [
@@ -132,8 +120,8 @@ def test_tmpdir_read_write(pytester: pytest.Pytester, parallel, it, passing):
     )
 
 
-@pytest.mark.parametrize("parallel, it, passing", parallel_threads)
-def test_tmpdir_delete(pytester: pytest.Pytester, parallel, it, passing):
+@pytest.mark.parametrize("parallel, passing", parallel_threads)
+def test_tmpdir_delete(pytester: pytest.Pytester, parallel, passing):
     # ensures we can delete files in each tmpdir
     pytester.makepyfile("""
         def test_tmpdir(tmpdir):
@@ -148,9 +136,7 @@ def test_tmpdir_delete(pytester: pytest.Pytester, parallel, it, passing):
             assert not subdir.check()
     """)
 
-    result = pytester.runpytest(
-        f"--parallel-threads={parallel}", f"--iterations={it}", "-v"
-    )
+    result = pytester.runpytest(f"--parallel-threads={parallel}", "-v")
 
     result.stdout.fnmatch_lines(
         [
@@ -159,24 +145,18 @@ def test_tmpdir_delete(pytester: pytest.Pytester, parallel, it, passing):
     )
 
 
-@pytest.mark.parametrize("parallel, it, passing", parallel_threads)
-def test_tmp_path_tmpdir(pytester: pytest.Pytester, parallel, it, passing):
+@pytest.mark.parametrize("parallel, passing", parallel_threads)
+def test_tmp_path_tmpdir(pytester: pytest.Pytester, parallel, passing):
     # ensures we can delete files in each tmpdir
     pytester.makepyfile("""
         def test_both(tmp_path, tmpdir):
             pass
     """)
 
-    result = pytester.runpytest(
-        f"--parallel-threads={parallel}", f"--iterations={it}", "-v"
-    )
+    result = pytester.runpytest(f"--parallel-threads={parallel}", "-v")
 
     result.stdout.fnmatch_lines(
         [
             f"*::test_both {passing}*",
         ]
     )
-
-
-def test_large_iterations(tmp_path):
-    print(tmp_path)

--- a/tests/test_tmp_path.py
+++ b/tests/test_tmp_path.py
@@ -1,17 +1,20 @@
 import pytest
 
 parallel_threads = [
-    (1, "PASSED"),  # no parallel threads
-    ("auto", "PARALLEL PASSED"),  # parallel threads
+    (1, 1, "PASSED"),  # no parallel threads
+    (1, 4, "PASSED"),  # no parallel threads
+    ("auto", 1, "PARALLEL PASSED"),  # parallel threads
+    ("auto", 4, "PARALLEL PASSED"),  # parallel threads
 ]
 
 
-@pytest.mark.parametrize("parallel, passing", parallel_threads)
-def test_tmp_path_is_empty(pytester: pytest.Pytester, parallel, passing):
+@pytest.mark.parametrize("parallel, it, passing", parallel_threads)
+def test_tmp_path_is_empty(pytester: pytest.Pytester, parallel, it, passing):
     # ensures tmp_path is empty for each thread
     # test from (gh-109)
     pytester.makepyfile("""
         def test_tmp_path(tmp_path):
+            print(tmp_path)
             assert tmp_path.exists()
             assert tmp_path.is_dir()
             assert len(list(tmp_path.iterdir())) == 0
@@ -21,7 +24,9 @@ def test_tmp_path_is_empty(pytester: pytest.Pytester, parallel, passing):
             assert d.exists()
     """)
 
-    result = pytester.runpytest(f"--parallel-threads={parallel}", "-v")
+    result = pytester.runpytest(
+        f"--parallel-threads={parallel}", f"--iterations={it}", "-v"
+    )
 
     result.stdout.fnmatch_lines(
         [
@@ -30,8 +35,8 @@ def test_tmp_path_is_empty(pytester: pytest.Pytester, parallel, passing):
     )
 
 
-@pytest.mark.parametrize("parallel, passing", parallel_threads)
-def test_tmp_path_read_write(pytester: pytest.Pytester, parallel, passing):
+@pytest.mark.parametrize("parallel, it, passing", parallel_threads)
+def test_tmp_path_read_write(pytester: pytest.Pytester, parallel, it, passing):
     # ensures we can read/write in each tmp_path
     pytester.makepyfile("""
         def test_tmp_path(tmp_path):
@@ -42,7 +47,9 @@ def test_tmp_path_read_write(pytester: pytest.Pytester, parallel, passing):
             assert file.read_text() == "Hello world!"
     """)
 
-    result = pytester.runpytest(f"--parallel-threads={parallel}", "-v")
+    result = pytester.runpytest(
+        f"--parallel-threads={parallel}", f"--iterations={it}", "-v"
+    )
 
     result.stdout.fnmatch_lines(
         [
@@ -51,8 +58,8 @@ def test_tmp_path_read_write(pytester: pytest.Pytester, parallel, passing):
     )
 
 
-@pytest.mark.parametrize("parallel, passing", parallel_threads)
-def test_tmp_path_delete(pytester: pytest.Pytester, parallel, passing):
+@pytest.mark.parametrize("parallel, it, passing", parallel_threads)
+def test_tmp_path_delete(pytester: pytest.Pytester, parallel, it, passing):
     # ensures we can delete files in each tmp_path
     pytester.makepyfile("""
         def test_tmp_path(tmp_path):
@@ -68,7 +75,9 @@ def test_tmp_path_delete(pytester: pytest.Pytester, parallel, passing):
             assert not subdir.exists()
     """)
 
-    result = pytester.runpytest(f"--parallel-threads={parallel}", "-v")
+    result = pytester.runpytest(
+        f"--parallel-threads={parallel}", f"--iterations={it}", "-v"
+    )
 
     result.stdout.fnmatch_lines(
         [
@@ -77,8 +86,8 @@ def test_tmp_path_delete(pytester: pytest.Pytester, parallel, passing):
     )
 
 
-@pytest.mark.parametrize("parallel, passing", parallel_threads)
-def test_tmpdir_is_empty(pytester: pytest.Pytester, parallel, passing):
+@pytest.mark.parametrize("parallel, it, passing", parallel_threads)
+def test_tmpdir_is_empty(pytester: pytest.Pytester, parallel, it, passing):
     # ensures tmpdir is empty for each thread
     pytester.makepyfile("""
         def test_tmpdir(tmpdir):
@@ -89,7 +98,9 @@ def test_tmpdir_is_empty(pytester: pytest.Pytester, parallel, passing):
             assert tmpdir.mkdir("sub").check()
     """)
 
-    result = pytester.runpytest(f"--parallel-threads={parallel}", "-v")
+    result = pytester.runpytest(
+        f"--parallel-threads={parallel}", f"--iterations={it}", "-v"
+    )
 
     result.stdout.fnmatch_lines(
         [
@@ -98,8 +109,8 @@ def test_tmpdir_is_empty(pytester: pytest.Pytester, parallel, passing):
     )
 
 
-@pytest.mark.parametrize("parallel, passing", parallel_threads)
-def test_tmpdir_read_write(pytester: pytest.Pytester, parallel, passing):
+@pytest.mark.parametrize("parallel, it, passing", parallel_threads)
+def test_tmpdir_read_write(pytester: pytest.Pytester, parallel, it, passing):
     # ensures we can read/write in each tmpdir
     pytester.makepyfile("""
         def test_tmpdir(tmpdir):
@@ -110,7 +121,9 @@ def test_tmpdir_read_write(pytester: pytest.Pytester, parallel, passing):
             assert file.read_text("utf-8") == "Hello world!"
     """)
 
-    result = pytester.runpytest(f"--parallel-threads={parallel}", "-v")
+    result = pytester.runpytest(
+        f"--parallel-threads={parallel}", f"--iterations={it}", "-v"
+    )
 
     result.stdout.fnmatch_lines(
         [
@@ -119,8 +132,8 @@ def test_tmpdir_read_write(pytester: pytest.Pytester, parallel, passing):
     )
 
 
-@pytest.mark.parametrize("parallel, passing", parallel_threads)
-def test_tmpdir_delete(pytester: pytest.Pytester, parallel, passing):
+@pytest.mark.parametrize("parallel, it, passing", parallel_threads)
+def test_tmpdir_delete(pytester: pytest.Pytester, parallel, it, passing):
     # ensures we can delete files in each tmpdir
     pytester.makepyfile("""
         def test_tmpdir(tmpdir):
@@ -135,10 +148,35 @@ def test_tmpdir_delete(pytester: pytest.Pytester, parallel, passing):
             assert not subdir.check()
     """)
 
-    result = pytester.runpytest(f"--parallel-threads={parallel}", "-v")
+    result = pytester.runpytest(
+        f"--parallel-threads={parallel}", f"--iterations={it}", "-v"
+    )
 
     result.stdout.fnmatch_lines(
         [
             f"*::test_tmpdir {passing}*",
         ]
     )
+
+
+@pytest.mark.parametrize("parallel, it, passing", parallel_threads)
+def test_tmp_path_tmpdir(pytester: pytest.Pytester, parallel, it, passing):
+    # ensures we can delete files in each tmpdir
+    pytester.makepyfile("""
+        def test_both(tmp_path, tmpdir):
+            pass
+    """)
+
+    result = pytester.runpytest(
+        f"--parallel-threads={parallel}", f"--iterations={it}", "-v"
+    )
+
+    result.stdout.fnmatch_lines(
+        [
+            f"*::test_both {passing}*",
+        ]
+    )
+
+
+def test_large_iterations(tmp_path):
+    print(tmp_path)

--- a/tests/test_tmp_path.py
+++ b/tests/test_tmp_path.py
@@ -1,16 +1,14 @@
 import pytest
 
-parallel_iterations = [
-    (1, 1, "PASSED"),  # no parallel threads, no iterations
-    ("auto", 1, "PARALLEL PASSED"),  # parallel threads, no iterations
-    (1, 5, "PASSED"),  # no parallel threads, iterations
-    ("auto", 5, "PARALLEL PASSED"),  # parallel threads and iterations
+parallel_threads = [
+    (1, "PASSED"),  # no parallel threads
+    ("auto", "PARALLEL PASSED"),  # parallel threads
 ]
 
 
-@pytest.mark.parametrize("parallel, iterations, passing", parallel_iterations)
-def test_tmp_path_is_empty(pytester: pytest.Pytester, parallel, iterations, passing):
-    # ensures tmp_path is empty for each thread/iteration
+@pytest.mark.parametrize("parallel, passing", parallel_threads)
+def test_tmp_path_is_empty(pytester: pytest.Pytester, parallel, passing):
+    # ensures tmp_path is empty for each thread
     # test from (gh-109)
     pytester.makepyfile("""
         def test_tmp_path(tmp_path):
@@ -23,9 +21,7 @@ def test_tmp_path_is_empty(pytester: pytest.Pytester, parallel, iterations, pass
             assert d.exists()
     """)
 
-    result = pytester.runpytest(
-        f"--parallel-threads={parallel}", f"--iterations={iterations}", "-v"
-    )
+    result = pytester.runpytest(f"--parallel-threads={parallel}", "-v")
 
     result.stdout.fnmatch_lines(
         [
@@ -34,8 +30,8 @@ def test_tmp_path_is_empty(pytester: pytest.Pytester, parallel, iterations, pass
     )
 
 
-@pytest.mark.parametrize("parallel, iterations, passing", parallel_iterations)
-def test_tmp_path_read_write(pytester: pytest.Pytester, parallel, iterations, passing):
+@pytest.mark.parametrize("parallel, passing", parallel_threads)
+def test_tmp_path_read_write(pytester: pytest.Pytester, parallel, passing):
     # ensures we can read/write in each tmp_path
     pytester.makepyfile("""
         def test_tmp_path(tmp_path):
@@ -46,9 +42,7 @@ def test_tmp_path_read_write(pytester: pytest.Pytester, parallel, iterations, pa
             assert file.read_text() == "Hello world!"
     """)
 
-    result = pytester.runpytest(
-        f"--parallel-threads={parallel}", f"--iterations={iterations}", "-v"
-    )
+    result = pytester.runpytest(f"--parallel-threads={parallel}", "-v")
 
     result.stdout.fnmatch_lines(
         [
@@ -57,8 +51,8 @@ def test_tmp_path_read_write(pytester: pytest.Pytester, parallel, iterations, pa
     )
 
 
-@pytest.mark.parametrize("parallel, iterations, passing", parallel_iterations)
-def test_tmp_path_delete(pytester: pytest.Pytester, parallel, iterations, passing):
+@pytest.mark.parametrize("parallel, passing", parallel_threads)
+def test_tmp_path_delete(pytester: pytest.Pytester, parallel, passing):
     # ensures we can delete files in each tmp_path
     pytester.makepyfile("""
         def test_tmp_path(tmp_path):
@@ -74,9 +68,7 @@ def test_tmp_path_delete(pytester: pytest.Pytester, parallel, iterations, passin
             assert not subdir.exists()
     """)
 
-    result = pytester.runpytest(
-        f"--parallel-threads={parallel}", f"--iterations={iterations}", "-v"
-    )
+    result = pytester.runpytest(f"--parallel-threads={parallel}", "-v")
 
     result.stdout.fnmatch_lines(
         [
@@ -85,9 +77,9 @@ def test_tmp_path_delete(pytester: pytest.Pytester, parallel, iterations, passin
     )
 
 
-@pytest.mark.parametrize("parallel, iterations, passing", parallel_iterations)
-def test_tmpdir_is_empty(pytester: pytest.Pytester, parallel, iterations, passing):
-    # ensures tmpdir is empty for each thread/iteration
+@pytest.mark.parametrize("parallel, passing", parallel_threads)
+def test_tmpdir_is_empty(pytester: pytest.Pytester, parallel, passing):
+    # ensures tmpdir is empty for each thread
     pytester.makepyfile("""
         def test_tmpdir(tmpdir):
             assert tmpdir.check()
@@ -97,9 +89,7 @@ def test_tmpdir_is_empty(pytester: pytest.Pytester, parallel, iterations, passin
             assert tmpdir.mkdir("sub").check()
     """)
 
-    result = pytester.runpytest(
-        f"--parallel-threads={parallel}", f"--iterations={iterations}", "-v"
-    )
+    result = pytester.runpytest(f"--parallel-threads={parallel}", "-v")
 
     result.stdout.fnmatch_lines(
         [
@@ -108,8 +98,8 @@ def test_tmpdir_is_empty(pytester: pytest.Pytester, parallel, iterations, passin
     )
 
 
-@pytest.mark.parametrize("parallel, iterations, passing", parallel_iterations)
-def test_tmpdir_read_write(pytester: pytest.Pytester, parallel, iterations, passing):
+@pytest.mark.parametrize("parallel, passing", parallel_threads)
+def test_tmpdir_read_write(pytester: pytest.Pytester, parallel, passing):
     # ensures we can read/write in each tmpdir
     pytester.makepyfile("""
         def test_tmpdir(tmpdir):
@@ -120,9 +110,7 @@ def test_tmpdir_read_write(pytester: pytest.Pytester, parallel, iterations, pass
             assert file.read_text("utf-8") == "Hello world!"
     """)
 
-    result = pytester.runpytest(
-        f"--parallel-threads={parallel}", f"--iterations={iterations}", "-v"
-    )
+    result = pytester.runpytest(f"--parallel-threads={parallel}", "-v")
 
     result.stdout.fnmatch_lines(
         [
@@ -131,8 +119,8 @@ def test_tmpdir_read_write(pytester: pytest.Pytester, parallel, iterations, pass
     )
 
 
-@pytest.mark.parametrize("parallel, iterations, passing", parallel_iterations)
-def test_tmpdir_delete(pytester: pytest.Pytester, parallel, iterations, passing):
+@pytest.mark.parametrize("parallel, passing", parallel_threads)
+def test_tmpdir_delete(pytester: pytest.Pytester, parallel, passing):
     # ensures we can delete files in each tmpdir
     pytester.makepyfile("""
         def test_tmpdir(tmpdir):
@@ -147,9 +135,7 @@ def test_tmpdir_delete(pytester: pytest.Pytester, parallel, iterations, passing)
             assert not subdir.check()
     """)
 
-    result = pytester.runpytest(
-        f"--parallel-threads={parallel}", f"--iterations={iterations}", "-v"
-    )
+    result = pytester.runpytest(f"--parallel-threads={parallel}", "-v")
 
     result.stdout.fnmatch_lines(
         [

--- a/tests/test_tmp_path.py
+++ b/tests/test_tmp_path.py
@@ -150,7 +150,9 @@ def test_tmp_path_tmpdir(pytester: pytest.Pytester, parallel, passing):
     # ensures tmp_path and tmpdir can be used at the same time
     pytester.makepyfile("""
         def test_both(tmp_path, tmpdir):
-            pass
+            assert tmp_path.exists()
+            assert tmpdir.check(dir=1)
+            assert tmp_path == tmpdir
     """)
 
     result = pytester.runpytest(f"--parallel-threads={parallel}", "-v")

--- a/tests/test_tmp_path.py
+++ b/tests/test_tmp_path.py
@@ -1,0 +1,157 @@
+import pytest
+
+parallel_iterations = [
+    (1, 1, "PASSED"),  # no parallel threads, no iterations
+    ("auto", 1, "PARALLEL PASSED"),  # parallel threads, no iterations
+    ("auto", 5, "PARALLEL PASSED"),  # parallel threads and iterations
+]
+
+
+@pytest.mark.parametrize("parallel, iterations, passing", parallel_iterations)
+def test_tmp_path_is_empty(pytester: pytest.Pytester, parallel, iterations, passing):
+    # ensures tmp_path is empty for each thread/iteration
+    # test from (gh-109)
+    pytester.makepyfile("""
+        def test_tmp_path(tmp_path):
+            assert tmp_path.exists()
+            assert tmp_path.is_dir()
+            assert len(list(tmp_path.iterdir())) == 0
+            d = tmp_path / "sub"
+            assert not d.exists()
+            d.mkdir()
+            assert d.exists()
+    """)
+
+    result = pytester.runpytest(
+        f"--parallel-threads={parallel}", f"--iterations={iterations}", "-v"
+    )
+
+    result.stdout.fnmatch_lines(
+        [
+            f"*::test_tmp_path {passing}*",
+        ]
+    )
+
+
+@pytest.mark.parametrize("parallel, iterations, passing", parallel_iterations)
+def test_tmp_path_read_write(pytester: pytest.Pytester, parallel, iterations, passing):
+    # ensures we can read/write in each tmp_path
+    pytester.makepyfile("""
+        def test_tmp_path(tmp_path):
+            file = tmp_path / "file"
+            with open(file, "w") as f:
+                f.write("Hello world!")
+            assert file.is_file()
+            assert file.read_text() == "Hello world!"
+    """)
+
+    result = pytester.runpytest(
+        f"--parallel-threads={parallel}", f"--iterations={iterations}", "-v"
+    )
+
+    result.stdout.fnmatch_lines(
+        [
+            f"*::test_tmp_path {passing}*",
+        ]
+    )
+
+
+@pytest.mark.parametrize("parallel, iterations, passing", parallel_iterations)
+def test_tmp_path_delete(pytester: pytest.Pytester, parallel, iterations, passing):
+    # ensures we can delete files in each tmp_path
+    pytester.makepyfile("""
+        def test_tmp_path(tmp_path):
+            subdir = tmp_path / "subdir"
+            subdir.mkdir()
+            file = subdir / "file"
+            with open(file, "w") as f:
+                f.write("Hello world!")
+            assert file.is_file()
+            file.unlink()
+            assert not file.exists()
+            subdir.rmdir()
+            assert not subdir.exists()
+    """)
+
+    result = pytester.runpytest(
+        f"--parallel-threads={parallel}", f"--iterations={iterations}", "-v"
+    )
+
+    result.stdout.fnmatch_lines(
+        [
+            f"*::test_tmp_path {passing}*",
+        ]
+    )
+
+
+@pytest.mark.parametrize("parallel, iterations, passing", parallel_iterations)
+def test_tmpdir_is_empty(pytester: pytest.Pytester, parallel, iterations, passing):
+    # ensures tmpdir is empty for each thread/iteration
+    pytester.makepyfile("""
+        def test_tmpdir(tmpdir):
+            assert tmpdir.check()
+            assert tmpdir.check(dir=1)
+            assert len(list(tmpdir.listdir())) == 0
+            assert not tmpdir.join("sub").check()
+            assert tmpdir.mkdir("sub").check()
+    """)
+
+    result = pytester.runpytest(
+        f"--parallel-threads={parallel}", f"--iterations={iterations}", "-v"
+    )
+
+    result.stdout.fnmatch_lines(
+        [
+            f"*::test_tmpdir {passing}*",
+        ]
+    )
+
+
+@pytest.mark.parametrize("parallel, iterations, passing", parallel_iterations)
+def test_tmpdir_read_write(pytester: pytest.Pytester, parallel, iterations, passing):
+    # ensures we can read/write in each tmpdir
+    pytester.makepyfile("""
+        def test_tmpdir(tmpdir):
+            file = tmpdir.join("file")
+            with open(file, "w") as f:
+                f.write("Hello world!")
+            assert file.check(file=1)
+            assert file.read_text("utf-8") == "Hello world!"
+    """)
+
+    result = pytester.runpytest(
+        f"--parallel-threads={parallel}", f"--iterations={iterations}", "-v"
+    )
+
+    result.stdout.fnmatch_lines(
+        [
+            f"*::test_tmpdir {passing}*",
+        ]
+    )
+
+
+@pytest.mark.parametrize("parallel, iterations, passing", parallel_iterations)
+def test_tmpdir_delete(pytester: pytest.Pytester, parallel, iterations, passing):
+    # ensures we can delete files in each tmpdir
+    pytester.makepyfile("""
+        def test_tmpdir(tmpdir):
+            subdir = tmpdir.mkdir("sub")
+            file = tmpdir.join("file")
+            with open(file, "w") as f:
+                f.write("Hello world!")
+            assert file.check(file=1)
+            file.remove()
+            assert not file.check()
+            subdir.remove()
+            assert not subdir.check()
+    """)
+
+    result = pytester.runpytest(
+        f"--parallel-threads={parallel}", f"--iterations={iterations}", "-v"
+    )
+
+    result.stdout.fnmatch_lines(
+        [
+            f"*::test_tmpdir {passing}*",
+        ]
+    )

--- a/tests/test_tmp_path.py
+++ b/tests/test_tmp_path.py
@@ -3,6 +3,7 @@ import pytest
 parallel_iterations = [
     (1, 1, "PASSED"),  # no parallel threads, no iterations
     ("auto", 1, "PARALLEL PASSED"),  # parallel threads, no iterations
+    (1, 5, "PASSED"),  # no parallel threads, iterations
     ("auto", 5, "PARALLEL PASSED"),  # parallel threads and iterations
 ]
 


### PR DESCRIPTION
This PR fixes #109, hoping to address the issue of tmp_path not being thread safe. The introduced changes will patch tmp_path (and tmpdir), creating sub-directories for each thread/iteration within the original path returned by tmp_path. The tmp_path fixture will then be set to the new path, so that tests using the fixture will have a new directory for each thread and iteration. This should prevent threads from reading/writing into the same files and causing conflicts.

This PR also introduces a change to the closure function in wrap_function_parallel, with functions that handle setup for patching fixtures. The thread_index and iteration_index code was moved to these setup functions, and the patching for tmp_path/tmpdir is handled here too.