### PR TITLE
Treat warnings as errors in tox tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ commands = [
     "--source=pytest_run_parallel,tests",
     "-m",
     "pytest",
+    "-W",
     "-v",
     "{posargs:tests}"
     ],


### PR DESCRIPTION
While helping @bwhitt7 with #123 I noticed that we weren't erroring on warnings. Let's do that.