### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.x
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,12 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell
+        additional_dependencies:
+          - tomli
   - repo: https://github.com/rstcheck/rstcheck
     rev: v6.2.5
     hooks:

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ those fixtures are shared between threads.
        adding support for Python 3.14 to a library that already
        runs tests under pytest-run-parallel on Python 3.13 or
        older.
-    - `--mark-hypothesis-as-unsafe` to always skip runing tests that
+    - `--mark-hypothesis-as-unsafe` to always skip running tests that
       use [hypothesis](https://github.com/hypothesisworks/hypothesis).
       While newer version of Hypothesis are thread-safe, and versions
       which are not are automatically skipped by `pytest-run-parallel`,
@@ -134,7 +134,7 @@ back to running all tests single-threaded.
 ## Requirements
 
 `pytest-run-parallel` depends exclusively on `pytest`. Optionally
-intalling `psutil` will help with identifying the number of logical
+installing `psutil` will help with identifying the number of logical
 cores available to the testing process in systems where that's not
 possible with the Python stdlib.
 
@@ -315,7 +315,7 @@ def test_skip_if_parallel(num_parallel_threads):
     ...
 ```
 
-The `thread_index` and `iteration_index` fixtures are also avaliable, which enable
+The `thread_index` and `iteration_index` fixtures are also available, which enable
 tests to display different behavior between threads and iterations.
 
 ```python


### PR DESCRIPTION
Fix typos discovered by codespell - https://pypi.org/project/codespell

% `codespell`
```
./README.md:75: runing ==> running, ruining
./README.md:137: intalling ==> installing
./README.md:318: avaliable ==> available
```
% `codespell --write-changes` 