### PR TITLE
Only run logic for selected pytest items

### DIFF
--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -238,7 +238,15 @@ class RunParallelPlugin:
 
         return True
 
-    @pytest.hookimpl(trylast=True)
+    # This is tryfirst=True because we need our plugin's pytest_collection_finish
+    # to be called before the terminal plugin's pytest_collection_finish:
+    #
+    # - pytest's terminal plugin hooks pytest_collection_finish, which calls
+    #   pytest_report_collectionfinish
+    # - we hook pytest_report_collectionfinish, assuming _handle_collected_item
+    #   has already been called for all items when pytest_report_collectionfinish
+    #   is called
+    @pytest.hookimpl(tryfirst=True)
     def pytest_collection_finish(self, session):
         for item in session.items:
             self._handle_collected_item(item)


### PR DESCRIPTION
Closes https://github.com/Quansight-Labs/pytest-run-parallel/issues/153.

[`pytest_collection_finish`](https://docs.pytest.org/en/7.1.x/reference/reference.html#pytest.hookspec.pytest_collection) is the right place to hook pytest for after exactly the tests we want have been selected. I don't think any pytest-run-parallel logic needs to execute for any non-selected item, so we can just wait until this stage in the process.

Note the pytest docs claim `4. Set session.items to the list of collected items` comes after `3. pytest_collection_finish(session)`, but I'm pretty sure this is a docs bug on pytest's end, and these steps should be reversed; I'll send a PR their way.

