### PR TITLE
v0.9.1 post-release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pytest-run-parallel"
 description = "A simple pytest plugin to run tests concurrently"
-version = "0.9.1"
+version = "0.9.1.dev0"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -384,7 +384,7 @@ wheels = [
 
 [[package]]
 name = "pytest-run-parallel"
-version = "0.9.1"
+version = "0.9.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "pytest" },


### PR DESCRIPTION
Forgot to do this for v0.9.0 but it's worth doing to have a more sensible development version string.