### PR TITLE
Use `=` as separator for the test run report

### DIFF
--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -354,7 +354,7 @@ class RunParallelPlugin:
         if not enabled:
             return
 
-        terminalreporter.section("pytest-run-parallel report", "*")
+        terminalreporter.section("pytest-run-parallel report", "=")
 
         if self.verbose and self.thread_unsafe:
             self._write_reasons_summary(terminalreporter)


### PR DESCRIPTION
I noticed that the parallel test run summary has been using `*` as the separator, which feels a bit odd when browsing the full pytest summary, since the rest of the native section headers provided by pytest use `=` as the separator. This PR changes it to use `=`. Would this be fine?

I checked the blame while opening this PR, and did not astutely find a reason as to why `*` was chosen. The `terminalreporter` was introduced in c37a9ca with `*` and stayed in subsequent commits, was reorganised in 63ef3b1 to become a section, and kept the same character.

So while `*` makes it easier to visually distinguish this section in GitHub Actions CI/local terminal logs, I'm not sure if this was a deliberate design choice. Something for consideration, maybe...