### PR TITLE
Respect verbosity/quietness settings when deciding to print the parallel report summary

### DIFF
--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -354,6 +354,9 @@ class RunParallelPlugin:
         if not enabled:
             return
 
+        if config.option.verbose < 0:
+            return
+
         terminalreporter.section("pytest-run-parallel report", "*")
 
         if self.verbose and self.thread_unsafe:

--- a/tests/test_run_parallel.py
+++ b/tests/test_run_parallel.py
@@ -731,6 +731,30 @@ def test_all_tests_in_parallel(pytester):
     )
 
 
+def test_report_visibility_respects_verbosity(pytester):
+    pytester.makepyfile("""
+    def test_parallel_1(num_parallel_threads):
+        assert num_parallel_threads == 10
+
+    def test_parallel_2(num_parallel_threads):
+        assert num_parallel_threads == 10
+    """)
+
+    # At the default verbosity the report is shown.
+    result = pytester.runpytest("--parallel-threads=10")
+    result.stdout.fnmatch_lines(
+        [
+            "*pytest-run-parallel report*",
+            "*All tests were run in parallel! 🎉*",
+        ]
+    )
+
+    # In quiet mode (-q) the report is suppressed entirely.
+    result = pytester.runpytest("--parallel-threads=10", "-q")
+    result.stdout.no_fnmatch_line("*pytest-run-parallel report*")
+    result.stdout.no_fnmatch_line("*All tests were run in parallel! 🎉*")
+
+
 def test_doctests_marked_thread_unsafe(pytester):
     pytester.makepyfile("""
     def test_parallel(num_parallel_threads):


### PR DESCRIPTION
The parallel tests section printed by `pytest_terminal_summary` ignored pytest's verbosity level, so it was always emitted, even under `-q` and `-qq`. This is a bit inconsistent with how pytest itself and other plugins usually behave in quiet mode, where auxiliary output is expected to be suppressed.

This PR prints the report based on pytest's verbosity, so it is no longer shown when the user explicitly requests quiet output.

See `pytest-xdist` here: https://github.com/pytest-dev/pytest-xdist/blob/7d2a2086f0d7c69bdabbc908157d1c0162244485/src/xdist/dsession.py#L276-L279, which also does the same and prints nothing in quiet mode.

I verified this manually in default and verbose modes and confirmed it's hidden in quiet mode, but I haven't added any tests (I don't think this needs an explicit test, as such).
