### PR TITLE
Configure per-test report to be displayed at higher verbosity modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,9 +379,11 @@ tests/test_kx.py ·....·
 
 Only the first and last tests are run in parallel.
 
-In order to list the tests that were marked as thread-unsafe and were
-not executed in parallel, you can set the `PYTEST_RUN_PARALLEL_VERBOSE`
-environment variable to 1.
+In order to list the individual tests that were marked as thread-unsafe and
+were not executed in parallel, run pytest with `-v` (or higher). You can get
+the same listing without raising pytest's verbosity by setting the
+`PYTEST_RUN_PARALLEL_VERBOSE` environment variable to 1. The summary report is
+shown by default and is suppressed when running quietly with `-q`.
 
 ## Contributing
 

--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -128,7 +128,10 @@ def wrap_function_parallel(fn, n_workers, n_iterations):
 
 class RunParallelPlugin:
     def __init__(self, config):
-        self.verbose = bool(int(os.environ.get("PYTEST_RUN_PARALLEL_VERBOSE", "0")))
+        self.verbose = (
+            bool(int(os.environ.get("PYTEST_RUN_PARALLEL_VERBOSE", "0")))
+            or config.option.verbose >= 1
+        )
         self.skip_thread_unsafe = config.option.skip_thread_unsafe
         self.mark_warnings_as_unsafe = config.option.mark_warnings_as_unsafe
         self.mark_ctypes_as_unsafe = config.option.mark_ctypes_as_unsafe
@@ -371,7 +374,7 @@ class RunParallelPlugin:
                 f"{num} {test} {self.skipped_or_not_parallel(plural=num > 1)}"
                 " because of use of thread-unsafe functionality, "
                 f"to list the tests that {self.skipped_or_not_parallel(plural=True)}, re-run "
-                "while setting PYTEST_RUN_PARALLEL_VERBOSE=1 "
+                "with -v or while setting PYTEST_RUN_PARALLEL_VERBOSE=1 "
                 "in your shell environment"
             )
         else:

--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -346,7 +346,7 @@ class RunParallelPlugin:
         for nodeid, reason in self.thread_unsafe.items():
             if reason is not None:
                 terminalreporter.line(
-                    f"{nodeid} {self.skipped_or_not_parallel(plural=False)} because it {reason}"
+                    f"{nodeid} {self.skipped_or_not_parallel(plural=False)}: {reason}"
                 )
             else:
                 terminalreporter.line(nodeid)

--- a/tests/test_run_parallel.py
+++ b/tests/test_run_parallel.py
@@ -760,9 +760,7 @@ def test_report_visibility_respects_verbosity(pytester):
         ],
         consecutive=True,
     )
-    result.stdout.no_fnmatch_line(
-        "*because of use of thread-unsafe functionality*"
-    )
+    result.stdout.no_fnmatch_line("*because of use of thread-unsafe functionality*")
 
     # In quiet mode (-q) the report is suppressed entirely.
     result = pytester.runpytest("--parallel-threads=10", "-q")

--- a/tests/test_run_parallel.py
+++ b/tests/test_run_parallel.py
@@ -285,18 +285,16 @@ def test_num_parallel_threads_fixture(pytester):
             "*::test_should_yield_global_threads PARALLEL PASSED*",
             "*::test_should_yield_marker_threads PARALLEL PASSED*",
             "*::test_single_threaded PASSED*",
-            "*1 test was not run in parallel because of use of "
-            "thread-unsafe functionality, to list the tests that "
-            "were not run in parallel, re-run while setting PYTEST_RUN_PARALLEL_VERBOSE=1"
-            " in your shell environment",
+            "*::test_single_threaded was not run in parallel:*",
         ]
     )
 
-    # Re-run with verbose output
+    # The detailed report is also produced via the environment variable alone,
+    # without raising pytest's verbosity.
     orig = os.environ.get("PYTEST_RUN_PARALLEL_VERBOSE", "0")
     os.environ["PYTEST_RUN_PARALLEL_VERBOSE"] = "1"
 
-    result = pytester.runpytest("--parallel-threads=10", "-v")
+    result = pytester.runpytest("--parallel-threads=10")
     os.environ["PYTEST_RUN_PARALLEL_VERBOSE"] = orig
 
     result.stdout.fnmatch_lines(
@@ -337,18 +335,16 @@ def test_parallel_threads_limit_fixture(pytester):
             "*::test_unaffected_by_thread_limit PARALLEL PASSED*",
             "*::test_less_than_thread_limit PARALLEL PASSED*",
             "*::test_single_threaded PASSED*",
-            "*1 test was not run in parallel because of use of "
-            "thread-unsafe functionality, to list the tests that "
-            "were not run in parallel, re-run while setting PYTEST_RUN_PARALLEL_VERBOSE=1"
-            " in your shell environment",
+            "*::test_single_threaded was not run in parallel:*",
         ]
     )
 
-    # Re-run with verbose output
+    # The detailed report is also produced via the environment variable alone,
+    # without raising pytest's verbosity.
     orig = os.environ.get("PYTEST_RUN_PARALLEL_VERBOSE", "0")
     os.environ["PYTEST_RUN_PARALLEL_VERBOSE"] = "1"
 
-    result = pytester.runpytest("--parallel-threads=10", "-v")
+    result = pytester.runpytest("--parallel-threads=10")
     os.environ["PYTEST_RUN_PARALLEL_VERBOSE"] = orig
 
     result.stdout.fnmatch_lines(
@@ -733,26 +729,44 @@ def test_all_tests_in_parallel(pytester):
 
 def test_report_visibility_respects_verbosity(pytester):
     pytester.makepyfile("""
-    def test_parallel_1(num_parallel_threads):
+    import pytest
+
+    def test_parallel(num_parallel_threads):
         assert num_parallel_threads == 10
 
-    def test_parallel_2(num_parallel_threads):
-        assert num_parallel_threads == 10
+    @pytest.mark.parallel_threads(1)
+    def test_single_threaded(num_parallel_threads):
+        assert num_parallel_threads == 1
     """)
 
-    # At the default verbosity the report is shown.
+    # At the default verbosity the report shows the condensed summary that
+    # points users at -v (or the environment variable) for the full listing.
     result = pytester.runpytest("--parallel-threads=10")
     result.stdout.fnmatch_lines(
         [
             "*pytest-run-parallel report*",
-            "*All tests were run in parallel! 🎉*",
+            "*1 test was not run in parallel because of use of "
+            "thread-unsafe functionality*",
         ]
+    )
+    result.stdout.no_fnmatch_line("*::test_single_threaded was not run in parallel*")
+
+    # With -v the report lists each test instead of the condensed summary.
+    result = pytester.runpytest("--parallel-threads=10", "-v")
+    result.stdout.fnmatch_lines(
+        [
+            "*pytest-run-parallel report*",
+            "*::test_single_threaded was not run in parallel:*",
+        ],
+        consecutive=True,
+    )
+    result.stdout.no_fnmatch_line(
+        "*because of use of thread-unsafe functionality*"
     )
 
     # In quiet mode (-q) the report is suppressed entirely.
     result = pytester.runpytest("--parallel-threads=10", "-q")
     result.stdout.no_fnmatch_line("*pytest-run-parallel report*")
-    result.stdout.no_fnmatch_line("*All tests were run in parallel! 🎉*")
 
 
 def test_doctests_marked_thread_unsafe(pytester):

--- a/tests/test_thread_unsafe_detection.py
+++ b/tests/test_thread_unsafe_detection.py
@@ -42,7 +42,9 @@ def test_thread_unsafe_marker(pytester):
         [
             "*::test_should_run_single PASSED*",
             "*::test_should_run_single_2 PASSED *thread-unsafe*: this is thread-unsafe*",
-            "*2 tests were not run in parallel*",
+            "*::test_should_run_single was not run in parallel:*",
+            "*::test_should_run_single_2 was not run in parallel:*"
+            "this is thread-unsafe*",
         ]
     )
 
@@ -55,7 +57,8 @@ def test_thread_unsafe_marker(pytester):
         [
             "*::test_should_run_single SKIPPED*",
             "*::test_should_run_single_2 SKIPPED*",
-            "*2 tests were skipped*",
+            "*::test_should_run_single was skipped:*",
+            "*::test_should_run_single_2 was skipped:*this is thread-unsafe*",
         ]
     )
 
@@ -357,12 +360,12 @@ def test_thread_unsafe_function_attr(pytester):
         ]
     )
 
+    # at the default verbosity the report shows the condensed count message
+    result = pytester.runpytest("--parallel-threads=10")
     result.stdout.fnmatch_lines(
         [
             "*3 tests were not run in parallel because of use of thread-unsafe "
-            "functionality, to list the tests that were not run in parallel, "
-            "re-run while setting PYTEST_RUN_PARALLEL_VERBOSE=1 in your "
-            "shell environment*",
+            "functionality*",
         ]
     )
 


### PR DESCRIPTION
From https://github.com/Quansight-Labs/pytest-run-parallel/pull/186#issuecomment-4813303292, this PR configures the per-test report that was previously displayed only via the environment variable `PYTEST_RUN_PARALLEL_VERBOSE` to also show up when `-v` and `-vv` flags are passed to `pytest`.

I also spotted a bit of a grammar issue with the "because it" phrase that we were using in the terminal reporter, which cannot apply to all unsafe test reason phrases. It can show up in this manner:

```ini
# reads fine
... test_plain_marker was not run in parallel because it uses the thread_unsafe marker

# broken
... test_custom_reason was not run in parallel because it this is thread-unsafe 
... test_single_threaded was not run in parallel because it test is marked as single-threaded
```

which I fixed by using a colon instead.