### PR TITLE
Add a hook so that downstream can use to wrap more fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,6 @@ target/
 
 # pyenv
 .python-version
+
+# Git worktrees
+.worktrees/

--- a/README.md
+++ b/README.md
@@ -135,6 +135,44 @@ temporary directory in that fixture.
 When using the fixtures `thread_index` and `iteration_index`, they should be
 requested directly by tests, and will return 0 when requested by other fixtures.
 
+### Extending per-thread fixture kwargs
+
+When pytest-run-parallel wraps tests for multiple threads and/or iterations, it
+calls `pytest_run_parallel_get_wrap_fixtures(n_workers)` once per session with
+the configured `--parallel-threads` value. Each implementation may return
+`None` (skip) or a dict mapping fixture names to transform callables:
+
+```python
+def transform(fixturevalue, *, thread_index):
+    return fixturevalue
+```
+
+Transforms may also be generators: the yielded value is used as the fixture
+value, and after the test body the generator is resumed for teardown. When
+several generator transforms run for a worker/iteration, teardowns run in
+reverse setup order.
+
+Per test, only transforms for fixtures requested directly by that test are
+kept. The plugin shallow-copies the fixture kwargs, then applies those
+transforms in order, chaining values. Dicts from multiple hookimpls are merged
+by appending transforms per fixture name (the same name registered twice runs
+both). The built-in implementation wraps `tmp_path` and `tmpdir` (when
+configured `n_workers > 1`). `thread_index` and `iteration_index` are set
+directly by the plugin.
+
+Example `conftest.py`:
+
+```python
+import pytest
+
+@pytest.hookimpl
+def pytest_run_parallel_get_wrap_fixtures(n_workers):
+    def transform_db(value, *, thread_index):
+        return value.for_thread(thread_index)
+
+    return {"db": transform_db}
+```
+
 **Note**: It's possible to specify `--parallel-threads=auto`,
 `pytest.mark.force_parallel_threads("auto")`, or
 `pytest.mark.parallel_threads_limit("auto")` which will let

--- a/README.md
+++ b/README.md
@@ -138,9 +138,13 @@ requested directly by tests, and will return 0 when requested by other fixtures.
 ### Extending per-thread fixture kwargs
 
 When pytest-run-parallel wraps tests for multiple threads and/or iterations, it
-calls `pytest_run_parallel_get_wrap_fixtures(n_workers)` once per session with
-the configured `--parallel-threads` value. Each implementation may return
-`None` (skip) or a dict mapping fixture names to transform callables:
+calls `pytest_run_parallel_get_wrap_fixtures(n_workers)` at collection time.
+`n_workers` is the number of threads the wrapped test will actually use, which
+markers like `force_parallel_threads` may set to a different value than the
+`--parallel-threads` option. Results are cached per distinct thread count, so
+the hook runs once per count rather than once per test. Each implementation
+may return `None` (skip) or a dict mapping fixture names to transform
+callables:
 
 ```python
 def transform(fixturevalue, *, thread_index):
@@ -150,15 +154,18 @@ def transform(fixturevalue, *, thread_index):
 Transforms may also be generators: the yielded value is used as the fixture
 value, and after the test body the generator is resumed for teardown. When
 several generator transforms run for a worker/iteration, teardowns run in
-reverse setup order.
+reverse setup order. An exception raised by a transform fails the test in
+every thread.
 
 Per test, only transforms for fixtures requested directly by that test are
 kept. The plugin shallow-copies the fixture kwargs, then applies those
 transforms in order, chaining values. Dicts from multiple hookimpls are merged
-by appending transforms per fixture name (the same name registered twice runs
-both). The built-in implementation wraps `tmp_path` and `tmpdir` (when
-configured `n_workers > 1`). `thread_index` and `iteration_index` are set
-directly by the plugin.
+per fixture name, and the same name registered twice runs both transforms,
+chained. Transforms from more specific hookimpls (which pluggy calls first,
+such as one in a nested `conftest.py`) are applied last, so they can wrap or
+override the others. The built-in implementation wraps `tmp_path` and `tmpdir`
+(when `n_workers > 1`). `thread_index` and `iteration_index` are set directly
+by the plugin.
 
 Example `conftest.py`:
 

--- a/README.md
+++ b/README.md
@@ -135,10 +135,10 @@ temporary directory in that fixture.
 When using the fixtures `thread_index` and `iteration_index`, they should be
 requested directly by tests, and will return 0 when requested by other fixtures.
 
-### Extending per-thread fixture kwargs
+### Per-thread fixture setups
 
 When pytest-run-parallel wraps tests for multiple threads and/or iterations, it
-calls `pytest_run_parallel_get_wrap_fixtures(n_workers)` at collection time.
+calls `pytest_run_parallel_get_thread_setups(n_workers)` at collection time.
 `n_workers` is the number of threads the wrapped test will actually use, which
 markers like `force_parallel_threads` may set to a different value than the
 `--parallel-threads` option. Results are cached per distinct thread count, so
@@ -173,7 +173,7 @@ Example `conftest.py`:
 import pytest
 
 @pytest.hookimpl
-def pytest_run_parallel_get_wrap_fixtures(n_workers):
+def pytest_run_parallel_get_thread_setups(n_workers):
     def transform_db(value, *, thread_index):
         return value.for_thread(thread_index)
 

--- a/src/pytest_run_parallel/hooks.py
+++ b/src/pytest_run_parallel/hooks.py
@@ -5,23 +5,33 @@ import pytest
 def pytest_run_parallel_get_wrap_fixtures(n_workers):
     """Return None, or a dict mapping fixture names to transform callables.
 
-    Called once per session to build the global wrap-fixtures map.
-    ``n_workers`` is the configured ``--parallel-threads`` value.
+    Called at collection time to build the wrap-fixtures map. ``n_workers``
+    is the number of threads that a wrapped test will actually use, which
+    markers such as ``force_parallel_threads`` may set to a different value
+    than the ``--parallel-threads`` option. Results are cached per distinct
+    thread count, so the hook runs once per count and not once per test.
 
     Each callable has the signature::
 
         transform(fixturevalue, *, thread_index) -> fixturevalue
 
-    A transform may also be a generator function (or otherwise return a
-    generator): the first yielded value is used as the fixture value, and after
-    the test body finishes the generator is resumed for teardown. When several
-    generator transforms run, teardowns execute in reverse setup order.
+    Transforms run in every worker thread, once per iteration, before the
+    barrier that synchronises the start of the test. A transform may also be
+    a generator function (or otherwise return a generator): the first yielded
+    value is used as the fixture value, and after the test body finishes the
+    generator is resumed for teardown. When several generator transforms run,
+    teardowns execute in reverse setup order. An exception raised by a
+    transform fails the test in every thread.
 
     Returning None skips this implementation. Non-None dicts from all hook
-    implementations are merged by appending transforms per fixture name (same
-    name registered twice means both run, in registration order).
+    implementations are merged per fixture name, and the same name registered
+    twice means both transforms run, chained. Transforms from more specific
+    hookimpls (which pluggy calls first, such as a nested conftest) are
+    applied last, so they can wrap or override the others.
 
-    Per test, only transforms for fixtures requested directly by that test are
-    applied. pytest-run-parallel shallow-copies kwargs, then applies those
-    transforms in order, chaining values.
+    Per test, only transforms for fixtures requested directly by that test
+    are applied. pytest-run-parallel shallow-copies kwargs, then applies
+    those transforms in order, chaining values. Note that a wrapped test
+    always runs in freshly spawned threads, even when ``n_workers`` is 1 and
+    only ``--iterations`` caused the wrapping.
     """

--- a/src/pytest_run_parallel/hooks.py
+++ b/src/pytest_run_parallel/hooks.py
@@ -2,10 +2,10 @@ import pytest
 
 
 @pytest.hookspec
-def pytest_run_parallel_get_wrap_fixtures(n_workers):
+def pytest_run_parallel_get_thread_setups(n_workers):
     """Return None, or a dict mapping fixture names to transform callables.
 
-    Called at collection time to build the wrap-fixtures map. ``n_workers``
+    Called at collection time to build the thread-setups map. ``n_workers``
     is the number of threads that a wrapped test will actually use, which
     markers such as ``force_parallel_threads`` may set to a different value
     than the ``--parallel-threads`` option. Results are cached per distinct

--- a/src/pytest_run_parallel/hooks.py
+++ b/src/pytest_run_parallel/hooks.py
@@ -1,0 +1,27 @@
+import pytest
+
+
+@pytest.hookspec
+def pytest_run_parallel_get_wrap_fixtures(n_workers):
+    """Return None, or a dict mapping fixture names to transform callables.
+
+    Called once per session to build the global wrap-fixtures map.
+    ``n_workers`` is the configured ``--parallel-threads`` value.
+
+    Each callable has the signature::
+
+        transform(fixturevalue, *, thread_index) -> fixturevalue
+
+    A transform may also be a generator function (or otherwise return a
+    generator): the first yielded value is used as the fixture value, and after
+    the test body finishes the generator is resumed for teardown. When several
+    generator transforms run, teardowns execute in reverse setup order.
+
+    Returning None skips this implementation. Non-None dicts from all hook
+    implementations are merged by appending transforms per fixture name (same
+    name registered twice means both run, in registration order).
+
+    Per test, only transforms for fixtures requested directly by that test are
+    applied. pytest-run-parallel shallow-copies kwargs, then applies those
+    transforms in order, chaining values.
+    """

--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -35,10 +35,10 @@ GIL_ENABLED_ERROR_TEXT = (
 )
 
 
-def _get_wrap_fixtures(config, n_workers):
+def _get_thread_setups(config, n_workers):
     """Merge hook results into name -> [transform, ...]."""
-    results = config.hook.pytest_run_parallel_get_wrap_fixtures(n_workers=n_workers)
-    wrap_fixtures = {}
+    results = config.hook.pytest_run_parallel_get_thread_setups(n_workers=n_workers)
+    thread_setups = {}
     for result in results:
         if not result:
             continue
@@ -46,21 +46,21 @@ def _get_wrap_fixtures(config, n_workers):
             # pluggy calls the most specific hookimpl first, so insert at
             # the beginning to apply its transform last, letting it wrap or
             # override the transforms of less specific hookimpls.
-            wrap_fixtures.setdefault(name, []).insert(0, transform)
-    return wrap_fixtures
+            thread_setups.setdefault(name, []).insert(0, transform)
+    return thread_setups
 
 
-def _wrap_fixtures_for_item(wrap_fixtures, item):
-    """Per-test subset of the global wrap-fixtures map."""
+def _thread_setups_for_item(thread_setups, item):
+    """Per-test subset of the global thread-setups map."""
     fixtures = getattr(item, "fixturenames", ())
     return {
         name: transforms
-        for name, transforms in wrap_fixtures.items()
+        for name, transforms in thread_setups.items()
         if name in fixtures
     }
 
 
-def _run_wrap_fixture_teardowns(teardowns):
+def _run_thread_setup_teardowns(teardowns):
     """Resume generator transforms after yield, in reverse setup order."""
     errors = []
     for gen in reversed(teardowns):
@@ -76,8 +76,8 @@ def _run_wrap_fixture_teardowns(teardowns):
         raise errors[0]
 
 
-def _apply_wrap_fixtures(
-    kwargs, wrap_fixtures, *, thread_index, iteration_index, n_workers
+def _apply_thread_setups(
+    kwargs, thread_setups, *, thread_index, iteration_index, n_workers
 ):
     worker_kwargs = dict(kwargs)
     if "iteration_index" in worker_kwargs:
@@ -87,7 +87,7 @@ def _apply_wrap_fixtures(
 
     teardowns = []
     try:
-        for name, transforms in wrap_fixtures.items():
+        for name, transforms in thread_setups.items():
             if name not in worker_kwargs:
                 continue
             value = worker_kwargs[name]
@@ -101,7 +101,7 @@ def _apply_wrap_fixtures(
             worker_kwargs[name] = value
     except BaseException:
         try:
-            _run_wrap_fixture_teardowns(teardowns)
+            _run_thread_setup_teardowns(teardowns)
         except Exception:
             # Surface the original transform error, not one raised while
             # unwinding the transforms that had already run.
@@ -110,9 +110,9 @@ def _apply_wrap_fixtures(
     return worker_kwargs, teardowns
 
 
-def wrap_function_parallel(fn, n_workers, n_iterations, wrap_fixtures=None):
-    if wrap_fixtures is None:
-        wrap_fixtures = {}
+def wrap_function_parallel(fn, n_workers, n_iterations, thread_setups=None):
+    if thread_setups is None:
+        thread_setups = {}
 
     @functools.wraps(fn)
     def inner(*args, **kwargs):
@@ -139,9 +139,9 @@ def wrap_function_parallel(fn, n_workers, n_iterations, wrap_fixtures=None):
 
                 for iteration_index in range(n_iterations):
                     try:
-                        worker_kwargs, teardowns = _apply_wrap_fixtures(
+                        worker_kwargs, teardowns = _apply_thread_setups(
                             kwargs,
-                            wrap_fixtures,
+                            thread_setups,
                             thread_index=thread_index,
                             iteration_index=iteration_index,
                             n_workers=n_workers,
@@ -174,7 +174,7 @@ def wrap_function_parallel(fn, n_workers, n_iterations, wrap_fixtures=None):
                             failed = f
                     finally:
                         try:
-                            _run_wrap_fixture_teardowns(teardowns)
+                            _run_thread_setup_teardowns(teardowns)
                         except Exception as e:
                             errors.append(e)
 
@@ -237,7 +237,7 @@ class RunParallelPlugin:
         self.unsafe_fixtures = construct_thread_unsafe_fixtures(config)
         self.thread_unsafe = {}
         self.run_in_parallel = {}
-        self._wrap_fixtures_cache = {}
+        self._thread_setups_cache = {}
 
     def skipped_or_not_parallel(self, *, plural):
         if plural:
@@ -343,14 +343,14 @@ class RunParallelPlugin:
         for item in session.items:
             self._handle_collected_item(item)
 
-    def _get_wrap_fixtures_cached(self, config, n_workers):
+    def _get_thread_setups_cached(self, config, n_workers):
         # The hook is called with the thread count each wrapped test will
         # actually use, which markers like force_parallel_threads may set
         # to a different value than the --parallel-threads option. Cache
         # per distinct count so the hook runs once per count, not per test.
-        if n_workers not in self._wrap_fixtures_cache:
-            self._wrap_fixtures_cache[n_workers] = _get_wrap_fixtures(config, n_workers)
-        return self._wrap_fixtures_cache[n_workers]
+        if n_workers not in self._thread_setups_cache:
+            self._thread_setups_cache[n_workers] = _get_thread_setups(config, n_workers)
+        return self._thread_setups_cache[n_workers]
 
     def _handle_collected_item(self, item):
         if isinstance(item, _pytest.doctest.DoctestItem):
@@ -399,11 +399,11 @@ class RunParallelPlugin:
 
         if n_workers > 1 or n_iterations > 1:
             original_globals = item.obj.__globals__
-            wrap_fixtures = _wrap_fixtures_for_item(
-                self._get_wrap_fixtures_cached(item.config, n_workers), item
+            thread_setups = _thread_setups_for_item(
+                self._get_thread_setups_cached(item.config, n_workers), item
             )
             item.obj = wrap_function_parallel(
-                item.obj, n_workers, n_iterations, wrap_fixtures
+                item.obj, n_workers, n_iterations, thread_setups
             )
             for name in original_globals:
                 if name not in item.obj.__globals__:
@@ -534,7 +534,7 @@ def thread_comp(num_parallel_threads):
 
 
 @pytest.hookimpl
-def pytest_run_parallel_get_wrap_fixtures(n_workers):
+def pytest_run_parallel_get_thread_setups(n_workers):
     """Built-in per-fixture transforms for parallel execution."""
     if n_workers <= 1:
         return None

--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -44,8 +44,9 @@ def _get_wrap_fixtures(config):
         if not result:
             continue
         for name, transform in result.items():
-            # insert at beginning, because pluggi will find the most
-            # specific one last (in practice this should not matter).
+            # pluggy calls the most specific hookimpl first, so insert at
+            # the beginning to apply its transform last, letting it wrap or
+            # override the transforms of less specific hookimpls.
             wrap_fixtures.setdefault(name, []).insert(0, transform)
     return wrap_fixtures
 

--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -35,9 +35,8 @@ GIL_ENABLED_ERROR_TEXT = (
 )
 
 
-def _get_wrap_fixtures(config):
-    """Merge hook results into name -> [transform, ...], preserving call order."""
-    n_workers = get_configured_num_workers(config)
+def _get_wrap_fixtures(config, n_workers):
+    """Merge hook results into name -> [transform, ...]."""
     results = config.hook.pytest_run_parallel_get_wrap_fixtures(n_workers=n_workers)
     wrap_fixtures = {}
     for result in results:
@@ -101,7 +100,12 @@ def _apply_wrap_fixtures(
                     value = result
             worker_kwargs[name] = value
     except BaseException:
-        _run_wrap_fixture_teardowns(teardowns)
+        try:
+            _run_wrap_fixture_teardowns(teardowns)
+        except Exception:
+            # Surface the original transform error, not one raised while
+            # unwinding the transforms that had already run.
+            pass
         raise
     return worker_kwargs, teardowns
 
@@ -134,27 +138,40 @@ def wrap_function_parallel(fn, n_workers, n_iterations, wrap_fixtures=None):
                 thread_index, args = args[0], args[1:]
 
                 for iteration_index in range(n_iterations):
-                    worker_kwargs, teardowns = _apply_wrap_fixtures(
-                        kwargs,
-                        wrap_fixtures,
-                        thread_index=thread_index,
-                        iteration_index=iteration_index,
-                        n_workers=n_workers,
-                    )
-
-                    barrier.wait()
                     try:
-                        fn(*args, **worker_kwargs)
-                    except Warning:
-                        pass
+                        worker_kwargs, teardowns = _apply_wrap_fixtures(
+                            kwargs,
+                            wrap_fixtures,
+                            thread_index=thread_index,
+                            iteration_index=iteration_index,
+                            n_workers=n_workers,
+                        )
                     except Exception as e:
                         errors.append(e)
-                    except _pytest.outcomes.Skipped as s:
-                        nonlocal skip
-                        skip = s.msg
-                    except _pytest.outcomes.Failed as f:
-                        nonlocal failed
-                        failed = f
+                        # Break the barrier so the other threads do not wait
+                        # forever for this one.
+                        barrier.abort()
+                        return
+
+                    try:
+                        try:
+                            barrier.wait()
+                        except threading.BrokenBarrierError:
+                            # Another thread failed during startup or while
+                            # applying its fixture transforms.
+                            return
+                        try:
+                            fn(*args, **worker_kwargs)
+                        except Warning:
+                            pass
+                        except Exception as e:
+                            errors.append(e)
+                        except _pytest.outcomes.Skipped as s:
+                            nonlocal skip
+                            skip = s.msg
+                        except _pytest.outcomes.Failed as f:
+                            nonlocal failed
+                            failed = f
                     finally:
                         try:
                             _run_wrap_fixture_teardowns(teardowns)
@@ -220,7 +237,7 @@ class RunParallelPlugin:
         self.unsafe_fixtures = construct_thread_unsafe_fixtures(config)
         self.thread_unsafe = {}
         self.run_in_parallel = {}
-        self.wrap_fixtures = None
+        self._wrap_fixtures_cache = {}
 
     def skipped_or_not_parallel(self, *, plural):
         if plural:
@@ -323,9 +340,17 @@ class RunParallelPlugin:
     #   is called
     @pytest.hookimpl(tryfirst=True)
     def pytest_collection_finish(self, session):
-        self.wrap_fixtures = _get_wrap_fixtures(session.config)
         for item in session.items:
             self._handle_collected_item(item)
+
+    def _get_wrap_fixtures_cached(self, config, n_workers):
+        # The hook is called with the thread count each wrapped test will
+        # actually use, which markers like force_parallel_threads may set
+        # to a different value than the --parallel-threads option. Cache
+        # per distinct count so the hook runs once per count, not per test.
+        if n_workers not in self._wrap_fixtures_cache:
+            self._wrap_fixtures_cache[n_workers] = _get_wrap_fixtures(config, n_workers)
+        return self._wrap_fixtures_cache[n_workers]
 
     def _handle_collected_item(self, item):
         if isinstance(item, _pytest.doctest.DoctestItem):
@@ -374,7 +399,9 @@ class RunParallelPlugin:
 
         if n_workers > 1 or n_iterations > 1:
             original_globals = item.obj.__globals__
-            wrap_fixtures = _wrap_fixtures_for_item(self.wrap_fixtures, item)
+            wrap_fixtures = _wrap_fixtures_for_item(
+                self._get_wrap_fixtures_cached(item.config, n_workers), item
+            )
             item.obj = wrap_function_parallel(
                 item.obj, n_workers, n_iterations, wrap_fixtures
             )

--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -38,9 +38,7 @@ GIL_ENABLED_ERROR_TEXT = (
 def _get_wrap_fixtures(config):
     """Merge hook results into name -> [transform, ...], preserving call order."""
     n_workers = get_configured_num_workers(config)
-    results = config.hook.pytest_run_parallel_get_wrap_fixtures(
-        n_workers=n_workers
-    )
+    results = config.hook.pytest_run_parallel_get_wrap_fixtures(n_workers=n_workers)
     wrap_fixtures = {}
     for result in results:
         if not result:
@@ -55,7 +53,11 @@ def _get_wrap_fixtures(config):
 def _wrap_fixtures_for_item(wrap_fixtures, item):
     """Per-test subset of the global wrap-fixtures map."""
     fixtures = getattr(item, "fixturenames", ())
-    return {name: transforms for name, transforms in wrap_fixtures.items() if name in fixtures}
+    return {
+        name: transforms
+        for name, transforms in wrap_fixtures.items()
+        if name in fixtures
+    }
 
 
 def _run_wrap_fixture_teardowns(teardowns):
@@ -74,7 +76,9 @@ def _run_wrap_fixture_teardowns(teardowns):
         raise errors[0]
 
 
-def _apply_wrap_fixtures(kwargs, wrap_fixtures, *, thread_index, iteration_index, n_workers):
+def _apply_wrap_fixtures(
+    kwargs, wrap_fixtures, *, thread_index, iteration_index, n_workers
+):
     worker_kwargs = dict(kwargs)
     if "iteration_index" in worker_kwargs:
         worker_kwargs["iteration_index"] = iteration_index

--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -553,11 +553,13 @@ def pytest_run_parallel_get_wrap_fixtures(n_workers):
     }
 
 
-def pytest_configure(config):
+def pytest_addhooks(pluginmanager):
     from pytest_run_parallel import hooks as run_parallel_hooks
 
-    config.pluginmanager.add_hookspecs(run_parallel_hooks)
+    pluginmanager.add_hookspecs(run_parallel_hooks)
 
+
+def pytest_configure(config):
     if (
         config.option.forever
         and (n := getattr(config.option, "numprocesses", None)) is not None

--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -1,4 +1,5 @@
 import functools
+import inspect
 import os
 import re
 import sys
@@ -34,7 +35,76 @@ GIL_ENABLED_ERROR_TEXT = (
 )
 
 
-def wrap_function_parallel(fn, n_workers, n_iterations):
+def _get_wrap_fixtures(config):
+    """Merge hook results into name -> [transform, ...], preserving call order."""
+    n_workers = get_configured_num_workers(config)
+    results = config.hook.pytest_run_parallel_get_wrap_fixtures(
+        n_workers=n_workers
+    )
+    wrap_fixtures = {}
+    for result in results:
+        if not result:
+            continue
+        for name, transform in result.items():
+            # insert at beginning, because pluggi will find the most
+            # specific one last (in practice this should not matter).
+            wrap_fixtures.setdefault(name, []).insert(0, transform)
+    return wrap_fixtures
+
+
+def _wrap_fixtures_for_item(wrap_fixtures, item):
+    """Per-test subset of the global wrap-fixtures map."""
+    fixtures = getattr(item, "fixturenames", ())
+    return {name: transforms for name, transforms in wrap_fixtures.items() if name in fixtures}
+
+
+def _run_wrap_fixture_teardowns(teardowns):
+    """Resume generator transforms after yield, in reverse setup order."""
+    errors = []
+    for gen in reversed(teardowns):
+        try:
+            next(gen)
+        except StopIteration:
+            pass
+        except Exception as e:
+            errors.append(e)
+        else:
+            gen.close()
+    if errors:
+        raise errors[0]
+
+
+def _apply_wrap_fixtures(kwargs, wrap_fixtures, *, thread_index, iteration_index, n_workers):
+    worker_kwargs = dict(kwargs)
+    if "iteration_index" in worker_kwargs:
+        worker_kwargs["iteration_index"] = iteration_index
+    if n_workers > 1 and "thread_index" in worker_kwargs:
+        worker_kwargs["thread_index"] = thread_index
+
+    teardowns = []
+    try:
+        for name, transforms in wrap_fixtures.items():
+            if name not in worker_kwargs:
+                continue
+            value = worker_kwargs[name]
+            for transform in transforms:
+                result = transform(value, thread_index=thread_index)
+                if inspect.isgenerator(result):
+                    value = next(result)
+                    teardowns.append(result)
+                else:
+                    value = result
+            worker_kwargs[name] = value
+    except BaseException:
+        _run_wrap_fixture_teardowns(teardowns)
+        raise
+    return worker_kwargs, teardowns
+
+
+def wrap_function_parallel(fn, n_workers, n_iterations, wrap_fixtures=None):
+    if wrap_fixtures is None:
+        wrap_fixtures = {}
+
     @functools.wraps(fn)
     def inner(*args, **kwargs):
         errors = []
@@ -57,27 +127,19 @@ def wrap_function_parallel(fn, n_workers, n_iterations):
             def closure(*args, **kwargs):
                 # "smuggling" thread_index into closure with args
                 thread_index, args = args[0], args[1:]
-                # modifying fixtures
-                if n_workers > 1:
-                    if "thread_index" in kwargs:
-                        kwargs["thread_index"] = thread_index
-                    if "tmp_path" in kwargs:
-                        kwargs["tmp_path"] = (
-                            kwargs["tmp_path"] / f"thread_{thread_index!s}"
-                        )
-                        kwargs["tmp_path"].mkdir(exist_ok=True)
-                    if "tmpdir" in kwargs:
-                        kwargs["tmpdir"] = kwargs["tmpdir"].ensure(
-                            f"thread_{thread_index!s}", dir=True
-                        )
 
-                for i in range(n_iterations):
-                    if "iteration_index" in kwargs:
-                        kwargs["iteration_index"] = i
+                for iteration_index in range(n_iterations):
+                    worker_kwargs, teardowns = _apply_wrap_fixtures(
+                        kwargs,
+                        wrap_fixtures,
+                        thread_index=thread_index,
+                        iteration_index=iteration_index,
+                        n_workers=n_workers,
+                    )
 
                     barrier.wait()
                     try:
-                        fn(*args, **kwargs)
+                        fn(*args, **worker_kwargs)
                     except Warning:
                         pass
                     except Exception as e:
@@ -88,15 +150,17 @@ def wrap_function_parallel(fn, n_workers, n_iterations):
                     except _pytest.outcomes.Failed as f:
                         nonlocal failed
                         failed = f
+                    finally:
+                        try:
+                            _run_wrap_fixture_teardowns(teardowns)
+                        except Exception as e:
+                            errors.append(e)
 
             workers = []
             for i in range(0, n_workers):
-                worker_kwargs = kwargs
                 # "smuggling" i into closure with args to use for thread_index fixture
                 workers.append(
-                    threading.Thread(
-                        target=closure, args=(i, *args), kwargs=worker_kwargs
-                    )
+                    threading.Thread(target=closure, args=(i, *args), kwargs=kwargs)
                 )
 
             num_completed = 0
@@ -151,6 +215,7 @@ class RunParallelPlugin:
         self.unsafe_fixtures = construct_thread_unsafe_fixtures(config)
         self.thread_unsafe = {}
         self.run_in_parallel = {}
+        self.wrap_fixtures = None
 
     def skipped_or_not_parallel(self, *, plural):
         if plural:
@@ -253,6 +318,7 @@ class RunParallelPlugin:
     #   is called
     @pytest.hookimpl(tryfirst=True)
     def pytest_collection_finish(self, session):
+        self.wrap_fixtures = _get_wrap_fixtures(session.config)
         for item in session.items:
             self._handle_collected_item(item)
 
@@ -303,7 +369,10 @@ class RunParallelPlugin:
 
         if n_workers > 1 or n_iterations > 1:
             original_globals = item.obj.__globals__
-            item.obj = wrap_function_parallel(item.obj, n_workers, n_iterations)
+            wrap_fixtures = _wrap_fixtures_for_item(self.wrap_fixtures, item)
+            item.obj = wrap_function_parallel(
+                item.obj, n_workers, n_iterations, wrap_fixtures
+            )
             for name in original_globals:
                 if name not in item.obj.__globals__:
                     item.obj.__globals__[name] = original_globals[name]
@@ -415,13 +484,13 @@ def num_iterations(request):
     return get_num_iterations(request.node)[0]
 
 
-# overwritten by wrap_function_parallel when using multiple threads
+# overwritten when using multiple threads
 @pytest.fixture
 def thread_index():
     return 0
 
 
-# overwritten by wrap_function_parallel when using multiple iterations
+# overwritten when using multiple iterations
 @pytest.fixture
 def iteration_index():
     return 0
@@ -432,7 +501,31 @@ def thread_comp(num_parallel_threads):
     return ThreadComparator(num_parallel_threads)
 
 
+@pytest.hookimpl
+def pytest_run_parallel_get_wrap_fixtures(n_workers):
+    """Built-in per-fixture transforms for parallel execution."""
+    if n_workers <= 1:
+        return None
+
+    def _tmp_path(value, *, thread_index):
+        path = value / f"thread_{thread_index!s}"
+        path.mkdir(exist_ok=True)
+        return path
+
+    def _tmpdir(value, *, thread_index):
+        return value.ensure(f"thread_{thread_index!s}", dir=True)
+
+    return {
+        "tmp_path": _tmp_path,
+        "tmpdir": _tmpdir,
+    }
+
+
 def pytest_configure(config):
+    from pytest_run_parallel import hooks as run_parallel_hooks
+
+    config.pluginmanager.add_hookspecs(run_parallel_hooks)
+
     if (
         config.option.forever
         and (n := getattr(config.option, "numprocesses", None)) is not None

--- a/tests/test_thread_setups.py
+++ b/tests/test_thread_setups.py
@@ -2,13 +2,13 @@ import pytest
 from _helpers import passing_status
 
 
-def test_wrap_fixtures_hook_can_transform_fixture(pytester: pytest.Pytester) -> None:
+def test_thread_setups_hook_can_transform_fixture(pytester: pytest.Pytester) -> None:
     pytester.makeconftest(
         """
         import pytest
 
         @pytest.hookimpl
-        def pytest_run_parallel_get_wrap_fixtures(n_workers):
+        def pytest_run_parallel_get_thread_setups(n_workers):
             def transform_marker(value, *, thread_index):
                 return f"{thread_index}:{value}"
 
@@ -36,13 +36,13 @@ def test_wrap_fixtures_hook_can_transform_fixture(pytester: pytest.Pytester) -> 
     result.stdout.fnmatch_lines([f"*::test_marker {passing_status(2)}*"])
 
 
-def test_wrap_fixtures_hook_none_is_skipped(pytester: pytest.Pytester) -> None:
+def test_thread_setups_hook_none_is_skipped(pytester: pytest.Pytester) -> None:
     pytester.makeconftest(
         """
         import pytest
 
         @pytest.hookimpl
-        def pytest_run_parallel_get_wrap_fixtures(n_workers):
+        def pytest_run_parallel_get_thread_setups(n_workers):
             return None
         """
     )
@@ -57,7 +57,7 @@ def test_wrap_fixtures_hook_none_is_skipped(pytester: pytest.Pytester) -> None:
     result.stdout.fnmatch_lines([f"*::test_thread_index {passing_status(2)}*"])
 
 
-def test_wrap_fixtures_hook_chains_duplicate_fixture_transforms(
+def test_thread_setups_hook_chains_duplicate_fixture_transforms(
     pytester: pytest.Pytester,
 ) -> None:
     pytester.makeconftest(
@@ -66,7 +66,7 @@ def test_wrap_fixtures_hook_chains_duplicate_fixture_transforms(
 
         class FirstPlugin:
             @pytest.hookimpl(tryfirst=True)
-            def pytest_run_parallel_get_wrap_fixtures(self, n_workers):
+            def pytest_run_parallel_get_thread_setups(self, n_workers):
                 def first(value, *, thread_index):
                     return value + ["first"]
 
@@ -74,7 +74,7 @@ def test_wrap_fixtures_hook_chains_duplicate_fixture_transforms(
 
         class SecondPlugin:
             @pytest.hookimpl(trylast=True)
-            def pytest_run_parallel_get_wrap_fixtures(self, n_workers):
+            def pytest_run_parallel_get_thread_setups(self, n_workers):
                 def second(value, *, thread_index):
                     return value + ["second"]
 
@@ -104,7 +104,7 @@ def test_wrap_fixtures_hook_chains_duplicate_fixture_transforms(
     result.stdout.fnmatch_lines([f"*::test_steps {passing_status(2)}*"])
 
 
-def test_wrap_fixtures_hook_generator_teardown_reverse_order(
+def test_thread_setups_hook_generator_teardown_reverse_order(
     pytester: pytest.Pytester,
 ) -> None:
     pytester.makeconftest(
@@ -115,7 +115,7 @@ def test_wrap_fixtures_hook_generator_teardown_reverse_order(
 
         class OuterPlugin:
             @pytest.hookimpl(tryfirst=True)
-            def pytest_run_parallel_get_wrap_fixtures(self, n_workers):
+            def pytest_run_parallel_get_thread_setups(self, n_workers):
                 def outer(value, *, thread_index):
                     log.append(f"setup-outer-{thread_index}")
                     yield value
@@ -125,7 +125,7 @@ def test_wrap_fixtures_hook_generator_teardown_reverse_order(
 
         class InnerPlugin:
             @pytest.hookimpl(trylast=True)
-            def pytest_run_parallel_get_wrap_fixtures(self, n_workers):
+            def pytest_run_parallel_get_thread_setups(self, n_workers):
                 def inner(value, *, thread_index):
                     log.append(f"setup-inner-{thread_index}")
                     yield f"{value}:{thread_index}"
@@ -172,7 +172,7 @@ def test_wrap_fixtures_hook_generator_teardown_reverse_order(
     )
 
 
-def test_wrap_fixtures_only_applies_to_direct_test_fixtures(
+def test_thread_setups_only_applies_to_direct_test_fixtures(
     pytester: pytest.Pytester,
 ) -> None:
     """Transforms for fixtures not requested by the test must not run."""
@@ -183,7 +183,7 @@ def test_wrap_fixtures_only_applies_to_direct_test_fixtures(
         calls = []
 
         @pytest.hookimpl
-        def pytest_run_parallel_get_wrap_fixtures(n_workers):
+        def pytest_run_parallel_get_thread_setups(n_workers):
             def transform_unused(value, *, thread_index):
                 calls.append("unused")
                 return value
@@ -210,7 +210,7 @@ def test_wrap_fixtures_only_applies_to_direct_test_fixtures(
     result.assert_outcomes(passed=1)
 
 
-def test_wrap_fixtures_skipped_when_configured_workers_is_one(
+def test_thread_setups_skipped_when_configured_workers_is_one(
     pytester: pytest.Pytester,
 ) -> None:
     """Built-in returns None when configured n_workers <= 1."""
@@ -224,7 +224,7 @@ def test_wrap_fixtures_skipped_when_configured_workers_is_one(
     result.assert_outcomes(passed=1)
 
 
-def test_wrap_fixtures_transform_failure_fails_test_without_hanging(
+def test_thread_setups_transform_failure_fails_test_without_hanging(
     pytester: pytest.Pytester,
 ) -> None:
     """A transform error must abort the barrier instead of deadlocking."""
@@ -233,7 +233,7 @@ def test_wrap_fixtures_transform_failure_fails_test_without_hanging(
         import pytest
 
         @pytest.hookimpl
-        def pytest_run_parallel_get_wrap_fixtures(n_workers):
+        def pytest_run_parallel_get_thread_setups(n_workers):
             def bad(value, *, thread_index):
                 if thread_index == 1:
                     raise RuntimeError("transform failed in thread 1")
@@ -263,7 +263,7 @@ def test_wrap_fixtures_transform_failure_fails_test_without_hanging(
     )
 
 
-def test_wrap_fixtures_teardown_runs_when_test_fails(
+def test_thread_setups_teardown_runs_when_test_fails(
     pytester: pytest.Pytester,
 ) -> None:
     pytester.makeconftest(
@@ -276,7 +276,7 @@ def test_wrap_fixtures_teardown_runs_when_test_fails(
         counts = {"teardown": 0}
 
         @pytest.hookimpl
-        def pytest_run_parallel_get_wrap_fixtures(n_workers):
+        def pytest_run_parallel_get_thread_setups(n_workers):
             def transform(value, *, thread_index):
                 yield value
                 with lock:
@@ -309,7 +309,7 @@ def test_wrap_fixtures_teardown_runs_when_test_fails(
     )
 
 
-def test_wrap_fixtures_most_specific_conftest_wins(
+def test_thread_setups_most_specific_conftest_wins(
     pytester: pytest.Pytester,
 ) -> None:
     pytester.makeconftest(
@@ -321,7 +321,7 @@ def test_wrap_fixtures_most_specific_conftest_wins(
             return "base"
 
         @pytest.hookimpl
-        def pytest_run_parallel_get_wrap_fixtures(n_workers):
+        def pytest_run_parallel_get_thread_setups(n_workers):
             def transform(value, *, thread_index):
                 return "root"
 
@@ -334,7 +334,7 @@ def test_wrap_fixtures_most_specific_conftest_wins(
                 import pytest
 
                 @pytest.hookimpl
-                def pytest_run_parallel_get_wrap_fixtures(n_workers):
+                def pytest_run_parallel_get_thread_setups(n_workers):
                     def transform(value, *, thread_index):
                         return "sub"
 
@@ -350,7 +350,7 @@ def test_wrap_fixtures_most_specific_conftest_wins(
     result.stdout.fnmatch_lines([f"*::test_resource {passing_status(2)}*"])
 
 
-def test_wrap_fixtures_hook_not_called_when_not_wrapped(
+def test_thread_setups_hook_not_called_when_not_wrapped(
     pytester: pytest.Pytester,
 ) -> None:
     pytester.makeconftest(
@@ -358,7 +358,7 @@ def test_wrap_fixtures_hook_not_called_when_not_wrapped(
         import pytest
 
         @pytest.hookimpl
-        def pytest_run_parallel_get_wrap_fixtures(n_workers):
+        def pytest_run_parallel_get_thread_setups(n_workers):
             raise RuntimeError("hook should not be called")
         """
     )
@@ -372,7 +372,7 @@ def test_wrap_fixtures_hook_not_called_when_not_wrapped(
     result.stdout.fnmatch_lines(["*::test_ok PASSED*"])
 
 
-def test_wrap_fixtures_forced_parallel_gets_tmp_path_isolation(
+def test_thread_setups_forced_parallel_gets_tmp_path_isolation(
     pytester: pytest.Pytester,
 ) -> None:
     """Built-ins must use the per-test thread count, not the CLI value"""

--- a/tests/test_wrap_fixtures.py
+++ b/tests/test_wrap_fixtures.py
@@ -94,7 +94,8 @@ def test_wrap_fixtures_hook_chains_duplicate_fixture_transforms(
             return []
 
         def test_steps(steps):
-            # Later hookimpls are inserted first (most-specific runs first).
+            # Hookimpls called first by pluggy (tryfirst, or a more specific
+            # conftest) have their transforms applied last, so they win.
             assert steps == ["second", "first"]
         """
     )
@@ -151,7 +152,8 @@ def test_wrap_fixtures_hook_generator_teardown_reverse_order(
         def test_teardown_order():
             from conftest import log
 
-            # Later hookimpls run first; teardowns still reverse of setup.
+            # Hookimpls called last are applied first. Teardowns run in
+            # reverse of setup order.
             for thread_index in (0, 1):
                 setup_inner = log.index(f"setup-inner-{thread_index}")
                 setup_outer = log.index(f"setup-outer-{thread_index}")

--- a/tests/test_wrap_fixtures.py
+++ b/tests/test_wrap_fixtures.py
@@ -1,0 +1,222 @@
+import pytest
+from _helpers import passing_status
+
+
+def test_wrap_fixtures_hook_can_transform_fixture(pytester: pytest.Pytester) -> None:
+    pytester.makeconftest(
+        """
+        import pytest
+
+        @pytest.hookimpl
+        def pytest_run_parallel_get_wrap_fixtures(n_workers):
+            def transform_marker(value, *, thread_index):
+                return f"{thread_index}:{value}"
+
+            return {"marker": transform_marker}
+        """
+    )
+    pytester.makepyfile(
+        """
+        import pytest
+
+        @pytest.fixture
+        def marker():
+            return "base"
+
+        def test_marker(marker, thread_comp):
+            assert marker.startswith(("0:", "1:"))
+            thread_index, value = marker.split(":", 1)
+            assert value == "base"
+            thread_comp(value=value)
+            assert int(thread_index) >= 0
+        """
+    )
+    result = pytester.runpytest("--parallel-threads=2", "-v")
+    result.assert_outcomes(passed=1)
+    result.stdout.fnmatch_lines([f"*::test_marker {passing_status(2)}*"])
+
+
+def test_wrap_fixtures_hook_none_is_skipped(pytester: pytest.Pytester) -> None:
+    pytester.makeconftest(
+        """
+        import pytest
+
+        @pytest.hookimpl
+        def pytest_run_parallel_get_wrap_fixtures(n_workers):
+            return None
+        """
+    )
+    pytester.makepyfile(
+        """
+        def test_thread_index(thread_index, num_parallel_threads):
+            assert thread_index < num_parallel_threads
+        """
+    )
+    result = pytester.runpytest("--parallel-threads=2", "-v")
+    result.assert_outcomes(passed=1)
+    result.stdout.fnmatch_lines([f"*::test_thread_index {passing_status(2)}*"])
+
+
+def test_wrap_fixtures_hook_chains_duplicate_fixture_transforms(
+    pytester: pytest.Pytester,
+) -> None:
+    pytester.makeconftest(
+        """
+        import pytest
+
+        class FirstPlugin:
+            @pytest.hookimpl(tryfirst=True)
+            def pytest_run_parallel_get_wrap_fixtures(self, n_workers):
+                def first(value, *, thread_index):
+                    return value + ["first"]
+
+                return {"steps": first}
+
+        class SecondPlugin:
+            @pytest.hookimpl(trylast=True)
+            def pytest_run_parallel_get_wrap_fixtures(self, n_workers):
+                def second(value, *, thread_index):
+                    return value + ["second"]
+
+                return {"steps": second}
+
+        def pytest_configure(config):
+            config.pluginmanager.register(FirstPlugin(), "first-prepare")
+            config.pluginmanager.register(SecondPlugin(), "second-prepare")
+        """
+    )
+    pytester.makepyfile(
+        """
+        import pytest
+
+        @pytest.fixture
+        def steps():
+            return []
+
+        def test_steps(steps):
+            # Later hookimpls are inserted first (most-specific runs first).
+            assert steps == ["second", "first"]
+        """
+    )
+    result = pytester.runpytest("--parallel-threads=2", "-v")
+    result.assert_outcomes(passed=1)
+    result.stdout.fnmatch_lines([f"*::test_steps {passing_status(2)}*"])
+
+
+def test_wrap_fixtures_hook_generator_teardown_reverse_order(
+    pytester: pytest.Pytester,
+) -> None:
+    pytester.makeconftest(
+        """
+        import pytest
+
+        log = []
+
+        class OuterPlugin:
+            @pytest.hookimpl(tryfirst=True)
+            def pytest_run_parallel_get_wrap_fixtures(self, n_workers):
+                def outer(value, *, thread_index):
+                    log.append(f"setup-outer-{thread_index}")
+                    yield value
+                    log.append(f"teardown-outer-{thread_index}")
+
+                return {"marker": outer}
+
+        class InnerPlugin:
+            @pytest.hookimpl(trylast=True)
+            def pytest_run_parallel_get_wrap_fixtures(self, n_workers):
+                def inner(value, *, thread_index):
+                    log.append(f"setup-inner-{thread_index}")
+                    yield f"{value}:{thread_index}"
+                    log.append(f"teardown-inner-{thread_index}")
+
+                return {"marker": inner}
+
+        def pytest_configure(config):
+            config.pluginmanager.register(OuterPlugin(), "outer-prepare")
+            config.pluginmanager.register(InnerPlugin(), "inner-prepare")
+        """
+    )
+    pytester.makepyfile(
+        """
+        import pytest
+
+        @pytest.fixture
+        def marker():
+            return "base"
+
+        def test_marker(marker, thread_index):
+            assert marker == f"base:{thread_index}"
+
+        def test_teardown_order():
+            from conftest import log
+
+            # Later hookimpls run first; teardowns still reverse of setup.
+            for thread_index in (0, 1):
+                setup_inner = log.index(f"setup-inner-{thread_index}")
+                setup_outer = log.index(f"setup-outer-{thread_index}")
+                teardown_outer = log.index(f"teardown-outer-{thread_index}")
+                teardown_inner = log.index(f"teardown-inner-{thread_index}")
+                assert setup_inner < setup_outer < teardown_outer < teardown_inner
+        """
+    )
+    result = pytester.runpytest("--parallel-threads=2", "-v")
+    result.assert_outcomes(passed=2)
+    result.stdout.fnmatch_lines(
+        [
+            f"*::test_marker {passing_status(2)}*",
+            f"*::test_teardown_order {passing_status(2)}*",
+        ]
+    )
+
+
+def test_wrap_fixtures_only_applies_to_direct_test_fixtures(
+    pytester: pytest.Pytester,
+) -> None:
+    """Transforms for fixtures not requested by the test must not run."""
+    pytester.makeconftest(
+        """
+        import pytest
+
+        calls = []
+
+        @pytest.hookimpl
+        def pytest_run_parallel_get_wrap_fixtures(n_workers):
+            def transform_unused(value, *, thread_index):
+                calls.append("unused")
+                return value
+
+            return {"unused": transform_unused}
+        """
+    )
+    pytester.makepyfile(
+        """
+        import pytest
+
+        @pytest.fixture
+        def unused():
+            return "x"
+
+        def test_no_unused(thread_index):
+            from conftest import calls
+
+            assert calls == []
+            assert thread_index >= 0
+        """
+    )
+    result = pytester.runpytest("--parallel-threads=2", "-v")
+    result.assert_outcomes(passed=1)
+
+
+def test_wrap_fixtures_skipped_when_configured_workers_is_one(
+    pytester: pytest.Pytester,
+) -> None:
+    """Built-in returns None when configured n_workers <= 1."""
+    pytester.makepyfile(
+        """
+        def test_thread_index(thread_index):
+            assert thread_index == 0
+        """
+    )
+    result = pytester.runpytest("--parallel-threads=1", "--iterations=2", "-v")
+    result.assert_outcomes(passed=1)

--- a/tests/test_wrap_fixtures.py
+++ b/tests/test_wrap_fixtures.py
@@ -222,3 +222,168 @@ def test_wrap_fixtures_skipped_when_configured_workers_is_one(
     )
     result = pytester.runpytest("--parallel-threads=1", "--iterations=2", "-v")
     result.assert_outcomes(passed=1)
+
+
+def test_wrap_fixtures_transform_failure_fails_test_without_hanging(
+    pytester: pytest.Pytester,
+) -> None:
+    """A transform error must abort the barrier instead of deadlocking."""
+    pytester.makeconftest(
+        """
+        import pytest
+
+        @pytest.hookimpl
+        def pytest_run_parallel_get_wrap_fixtures(n_workers):
+            def bad(value, *, thread_index):
+                if thread_index == 1:
+                    raise RuntimeError("transform failed in thread 1")
+                return value
+
+            return {"resource": bad}
+        """
+    )
+    pytester.makepyfile(
+        """
+        import pytest
+
+        @pytest.fixture
+        def resource():
+            return "base"
+
+        def test_resource(resource):
+            pass
+        """
+    )
+    result = pytester.runpytest("--parallel-threads=4", "-v")
+    result.stdout.fnmatch_lines(
+        [
+            "*::test_resource PARALLEL FAILED*",
+            "*transform failed in thread 1*",
+        ]
+    )
+
+
+def test_wrap_fixtures_teardown_runs_when_test_fails(
+    pytester: pytest.Pytester,
+) -> None:
+    pytester.makeconftest(
+        """
+        import threading
+
+        import pytest
+
+        lock = threading.Lock()
+        counts = {"teardown": 0}
+
+        @pytest.hookimpl
+        def pytest_run_parallel_get_wrap_fixtures(n_workers):
+            def transform(value, *, thread_index):
+                yield value
+                with lock:
+                    counts["teardown"] += 1
+
+            return {"resource": transform}
+
+        def pytest_terminal_summary(terminalreporter, exitstatus, config):
+            terminalreporter.line(f"teardown={counts['teardown']}")
+        """
+    )
+    pytester.makepyfile(
+        """
+        import pytest
+
+        @pytest.fixture
+        def resource():
+            return "base"
+
+        def test_fails(resource):
+            raise ValueError("boom")
+        """
+    )
+    result = pytester.runpytest("--parallel-threads=2", "-v")
+    result.stdout.fnmatch_lines(
+        [
+            "*::test_fails PARALLEL FAILED*",
+            "teardown=2",
+        ]
+    )
+
+
+def test_wrap_fixtures_most_specific_conftest_wins(
+    pytester: pytest.Pytester,
+) -> None:
+    pytester.makeconftest(
+        """
+        import pytest
+
+        @pytest.fixture
+        def resource():
+            return "base"
+
+        @pytest.hookimpl
+        def pytest_run_parallel_get_wrap_fixtures(n_workers):
+            def transform(value, *, thread_index):
+                return "root"
+
+            return {"resource": transform}
+        """
+    )
+    pytester.makepyfile(
+        **{
+            "sub/conftest": """
+                import pytest
+
+                @pytest.hookimpl
+                def pytest_run_parallel_get_wrap_fixtures(n_workers):
+                    def transform(value, *, thread_index):
+                        return "sub"
+
+                    return {"resource": transform}
+            """,
+            "sub/test_order": """
+                def test_resource(resource):
+                    assert resource == "sub"
+            """,
+        }
+    )
+    result = pytester.runpytest("--parallel-threads=2", "-v")
+    result.stdout.fnmatch_lines([f"*::test_resource {passing_status(2)}*"])
+
+
+def test_wrap_fixtures_hook_not_called_when_not_wrapped(
+    pytester: pytest.Pytester,
+) -> None:
+    pytester.makeconftest(
+        """
+        import pytest
+
+        @pytest.hookimpl
+        def pytest_run_parallel_get_wrap_fixtures(n_workers):
+            raise RuntimeError("hook should not be called")
+        """
+    )
+    pytester.makepyfile(
+        """
+        def test_ok():
+            pass
+        """
+    )
+    result = pytester.runpytest("--parallel-threads=1", "-v")
+    result.stdout.fnmatch_lines(["*::test_ok PASSED*"])
+
+
+def test_wrap_fixtures_forced_parallel_gets_tmp_path_isolation(
+    pytester: pytest.Pytester,
+) -> None:
+    """Built-ins must use the per-test thread count, not the CLI value"""
+    pytester.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.force_parallel_threads(2)
+        def test_tmp(tmp_path, thread_index):
+            assert tmp_path.name == f"thread_{thread_index}"
+        """
+    )
+    result = pytester.runpytest("-v")
+    result.stdout.fnmatch_lines(["*::test_tmp PARALLEL PASSED*"])


### PR DESCRIPTION
This uses a hook to setup wrapping of fixtures and also uses that for tmp_dir and tmp_path.

Discussed and worked in with @agriyakhetarpal.  We decided on this approach of returning a dict, discarding the idea of calling the original fixture function again, because that requires reaching into private pytest API (probably works in practice, but...).

(Large written with agent, at least the tests probably need one iteration, the code should be OK enough.).

Closes gh-189