### PR TITLE
Create a separate tmpdir/tmp_path subdirectory for each iteration, so these fixtures can work with --iterations

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ those fixtures are shared between threads.
 
 - Modifications to existing fixtures:
     - `tmp_path` and `tmpdir`: Patched to be thread-safe, with individual
-      subdirectories being created for each thread.
+      subdirectories being created for each thread and test iteration if using `--iterations`.
 
 While pytest-run-parallel has special handling for the `tmp_path` and `tmpdir`
 fixtures to ensure that each thread has a private temporary directory, the

--- a/README.md
+++ b/README.md
@@ -122,9 +122,7 @@ those fixtures are shared between threads.
 
 - Modifications to existing fixtures:
     - `tmp_path` and `tmpdir`: Patched to be thread-safe, with individual
-    subdirectories being created for each thread. Subdirectories are not
-    created for each iteration, so you may see issues with reused temporary
-    directions when using `--iterations`.
+      subdirectories being created for each thread.
 
 While pytest-run-parallel has special handling for the `tmp_path` and `tmpdir`
 fixtures to ensure that each thread has a private temporary directory, the

--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -38,11 +38,6 @@ def _add_temp_subdirectory(kwargs: dict[str, object], subdir: str) -> None:
     """
     Add a subdirectory with the given name to tmp_path/tmpdir fixtures.
     """
-    if "tmp_path" in kwargs:
-        kwargs["tmp_path"] = kwargs["tmp_path"] / subdir
-        kwargs["tmp_path"].mkdir(exist_ok=True)
-    if "tmpdir" in kwargs:
-        kwargs["tmpdir"] = kwargs["tmpdir"].ensure(subdir, dir=True)
 
 
 def wrap_function_parallel(fn, n_workers, n_iterations):
@@ -72,12 +67,19 @@ def wrap_function_parallel(fn, n_workers, n_iterations):
                 if n_workers > 1:
                     if "thread_index" in kwargs:
                         kwargs["thread_index"] = thread_index
-                    _add_temp_subdirectory(kwargs, f"thread_{thread_index!s}")
 
                 for i in range(n_iterations):
                     if "iteration_index" in kwargs:
                         kwargs["iteration_index"] = i
-                    _add_temp_subdirectory(kwargs, f"iteration_{i}")
+                    if "tmp_path" in kwargs:
+                        kwargs["tmp_path"] = (
+                            kwargs["tmp_path"] / f"thread_{thread_index!s}_iter_{i}"
+                        )
+                        kwargs["tmp_path"].mkdir(exist_ok=True)
+                    if "tmpdir" in kwargs:
+                        kwargs["tmpdir"] = kwargs["tmpdir"].ensure(
+                            f"thread_{thread_index!s}_iter_{i}", dir=True
+                        )
 
                     barrier.wait()
                     try:

--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -62,16 +62,19 @@ def wrap_function_parallel(fn, n_workers, n_iterations):
                     if "thread_index" in kwargs:
                         kwargs["thread_index"] = thread_index
 
+                base_tmp_path = kwargs.get("tmp_path", None)
+                base_tmpdir = kwargs.get("tmpdir", None)
+
                 for i in range(n_iterations):
                     if "iteration_index" in kwargs:
                         kwargs["iteration_index"] = i
-                    if "tmp_path" in kwargs:
+                    if base_tmp_path is not None:
                         kwargs["tmp_path"] = (
-                            kwargs["tmp_path"] / f"thread_{thread_index!s}_iter_{i}"
+                            base_tmp_path / f"thread_{thread_index!s}_iter_{i}"
                         )
                         kwargs["tmp_path"].mkdir()
-                    if "tmpdir" in kwargs:
-                        kwargs["tmpdir"] = kwargs["tmpdir"].ensure(
+                    if base_tmpdir is not None:
+                        kwargs["tmpdir"] = base_tmpdir.ensure(
                             f"thread_{thread_index!s}_iter_{i}", dir=True
                         )
 

--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -34,12 +34,6 @@ GIL_ENABLED_ERROR_TEXT = (
 )
 
 
-def _add_temp_subdirectory(kwargs: dict[str, object], subdir: str) -> None:
-    """
-    Add a subdirectory with the given name to tmp_path/tmpdir fixtures.
-    """
-
-
 def wrap_function_parallel(fn, n_workers, n_iterations):
     @functools.wraps(fn)
     def inner(*args, **kwargs):

--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -34,6 +34,17 @@ GIL_ENABLED_ERROR_TEXT = (
 )
 
 
+def _add_temp_subdirectory(kwargs: dict[str, object], subdir: str) -> None:
+    """
+    Add a subdirectory with the given name to tmp_path/tmpdir fixtures.
+    """
+    if "tmp_path" in kwargs:
+        kwargs["tmp_path"] = kwargs["tmp_path"] / subdir
+        kwargs["tmp_path"].mkdir(exist_ok=True)
+    if "tmpdir" in kwargs:
+        kwargs["tmpdir"] = kwargs["tmpdir"].ensure(subdir, dir=True)
+
+
 def wrap_function_parallel(fn, n_workers, n_iterations):
     @functools.wraps(fn)
     def inner(*args, **kwargs):
@@ -61,19 +72,12 @@ def wrap_function_parallel(fn, n_workers, n_iterations):
                 if n_workers > 1:
                     if "thread_index" in kwargs:
                         kwargs["thread_index"] = thread_index
-                    if "tmp_path" in kwargs:
-                        kwargs["tmp_path"] = (
-                            kwargs["tmp_path"] / f"thread_{thread_index!s}"
-                        )
-                        kwargs["tmp_path"].mkdir(exist_ok=True)
-                    if "tmpdir" in kwargs:
-                        kwargs["tmpdir"] = kwargs["tmpdir"].ensure(
-                            f"thread_{thread_index!s}", dir=True
-                        )
+                    _add_temp_subdirectory(kwargs, f"thread_{thread_index!s}")
 
                 for i in range(n_iterations):
                     if "iteration_index" in kwargs:
                         kwargs["iteration_index"] = i
+                    _add_temp_subdirectory(kwargs, f"iteration_{i}")
 
                     barrier.wait()
                     try:

--- a/src/pytest_run_parallel/plugin.py
+++ b/src/pytest_run_parallel/plugin.py
@@ -69,7 +69,7 @@ def wrap_function_parallel(fn, n_workers, n_iterations):
                         kwargs["tmp_path"] = (
                             kwargs["tmp_path"] / f"thread_{thread_index!s}_iter_{i}"
                         )
-                        kwargs["tmp_path"].mkdir(exist_ok=True)
+                        kwargs["tmp_path"].mkdir()
                     if "tmpdir" in kwargs:
                         kwargs["tmpdir"] = kwargs["tmpdir"].ensure(
                             f"thread_{thread_index!s}_iter_{i}", dir=True

--- a/tests/test_tmp_path.py
+++ b/tests/test_tmp_path.py
@@ -2,10 +2,12 @@ import pytest
 from _helpers import passing_status
 
 parallel_threads = [1, "auto"]
+num_iterations = [1, 2]
 
 
 @pytest.mark.parametrize("parallel", parallel_threads)
-def test_tmp_path_is_empty(pytester: pytest.Pytester, parallel):
+@pytest.mark.parametrize("iterations", num_iterations)
+def test_tmp_path_is_empty(pytester: pytest.Pytester, parallel, iterations):
     # ensures tmp_path is empty for each thread
     # test from (gh-109)
     pytester.makepyfile("""
@@ -20,7 +22,9 @@ def test_tmp_path_is_empty(pytester: pytest.Pytester, parallel):
             assert d.exists()
     """)
 
-    result = pytester.runpytest(f"--parallel-threads={parallel}", "-v")
+    result = pytester.runpytest(
+        f"--parallel-threads={parallel}", f"--iterations={iterations}", "-v"
+    )
 
     result.stdout.fnmatch_lines(
         [
@@ -30,7 +34,8 @@ def test_tmp_path_is_empty(pytester: pytest.Pytester, parallel):
 
 
 @pytest.mark.parametrize("parallel", parallel_threads)
-def test_tmp_path_read_write(pytester: pytest.Pytester, parallel):
+@pytest.mark.parametrize("iterations", num_iterations)
+def test_tmp_path_read_write(pytester: pytest.Pytester, parallel, iterations):
     # ensures we can read/write in each tmp_path
     pytester.makepyfile("""
         def test_tmp_path(tmp_path):
@@ -41,7 +46,9 @@ def test_tmp_path_read_write(pytester: pytest.Pytester, parallel):
             assert file.read_text() == "Hello world!"
     """)
 
-    result = pytester.runpytest(f"--parallel-threads={parallel}", "-v")
+    result = pytester.runpytest(
+        f"--parallel-threads={parallel}", f"--iterations={iterations}", "-v"
+    )
 
     result.stdout.fnmatch_lines(
         [
@@ -51,7 +58,8 @@ def test_tmp_path_read_write(pytester: pytest.Pytester, parallel):
 
 
 @pytest.mark.parametrize("parallel", parallel_threads)
-def test_tmp_path_delete(pytester: pytest.Pytester, parallel):
+@pytest.mark.parametrize("iterations", num_iterations)
+def test_tmp_path_delete(pytester: pytest.Pytester, parallel, iterations):
     # ensures we can delete files in each tmp_path
     pytester.makepyfile("""
         def test_tmp_path(tmp_path):
@@ -67,7 +75,9 @@ def test_tmp_path_delete(pytester: pytest.Pytester, parallel):
             assert not subdir.exists()
     """)
 
-    result = pytester.runpytest(f"--parallel-threads={parallel}", "-v")
+    result = pytester.runpytest(
+        f"--parallel-threads={parallel}", f"--iterations={iterations}", "-v"
+    )
 
     result.stdout.fnmatch_lines(
         [
@@ -77,7 +87,8 @@ def test_tmp_path_delete(pytester: pytest.Pytester, parallel):
 
 
 @pytest.mark.parametrize("parallel", parallel_threads)
-def test_tmpdir_is_empty(pytester: pytest.Pytester, parallel):
+@pytest.mark.parametrize("iterations", num_iterations)
+def test_tmpdir_is_empty(pytester: pytest.Pytester, parallel, iterations):
     # ensures tmpdir is empty for each thread
     pytester.makepyfile("""
         def test_tmpdir(tmpdir):
@@ -88,7 +99,9 @@ def test_tmpdir_is_empty(pytester: pytest.Pytester, parallel):
             assert tmpdir.mkdir("sub").check()
     """)
 
-    result = pytester.runpytest(f"--parallel-threads={parallel}", "-v")
+    result = pytester.runpytest(
+        f"--parallel-threads={parallel}", f"--iterations={iterations}", "-v"
+    )
 
     result.stdout.fnmatch_lines(
         [
@@ -98,7 +111,8 @@ def test_tmpdir_is_empty(pytester: pytest.Pytester, parallel):
 
 
 @pytest.mark.parametrize("parallel", parallel_threads)
-def test_tmpdir_read_write(pytester: pytest.Pytester, parallel):
+@pytest.mark.parametrize("iterations", num_iterations)
+def test_tmpdir_read_write(pytester: pytest.Pytester, parallel, iterations):
     # ensures we can read/write in each tmpdir
     pytester.makepyfile("""
         def test_tmpdir(tmpdir):
@@ -109,7 +123,9 @@ def test_tmpdir_read_write(pytester: pytest.Pytester, parallel):
             assert file.read_text("utf-8") == "Hello world!"
     """)
 
-    result = pytester.runpytest(f"--parallel-threads={parallel}", "-v")
+    result = pytester.runpytest(
+        f"--parallel-threads={parallel}", f"--iterations={iterations}", "-v"
+    )
 
     result.stdout.fnmatch_lines(
         [
@@ -119,7 +135,8 @@ def test_tmpdir_read_write(pytester: pytest.Pytester, parallel):
 
 
 @pytest.mark.parametrize("parallel", parallel_threads)
-def test_tmpdir_delete(pytester: pytest.Pytester, parallel):
+@pytest.mark.parametrize("iterations", num_iterations)
+def test_tmpdir_delete(pytester: pytest.Pytester, parallel, iterations):
     # ensures we can delete files in each tmpdir
     pytester.makepyfile("""
         def test_tmpdir(tmpdir):
@@ -134,7 +151,9 @@ def test_tmpdir_delete(pytester: pytest.Pytester, parallel):
             assert not subdir.check()
     """)
 
-    result = pytester.runpytest(f"--parallel-threads={parallel}", "-v")
+    result = pytester.runpytest(
+        f"--parallel-threads={parallel}", f"--iterations={iterations}", "-v"
+    )
 
     result.stdout.fnmatch_lines(
         [
@@ -144,7 +163,8 @@ def test_tmpdir_delete(pytester: pytest.Pytester, parallel):
 
 
 @pytest.mark.parametrize("parallel", parallel_threads)
-def test_tmp_path_tmpdir(pytester: pytest.Pytester, parallel):
+@pytest.mark.parametrize("iterations", num_iterations)
+def test_tmp_path_tmpdir(pytester: pytest.Pytester, parallel, iterations):
     # ensures tmp_path and tmpdir can be used at the same time
     pytester.makepyfile("""
         def test_both(tmp_path, tmpdir):
@@ -153,7 +173,9 @@ def test_tmp_path_tmpdir(pytester: pytest.Pytester, parallel):
             assert tmp_path == tmpdir
     """)
 
-    result = pytester.runpytest(f"--parallel-threads={parallel}", "-v")
+    result = pytester.runpytest(
+        f"--parallel-threads={parallel}", f"--iterations={iterations}", "-v"
+    )
 
     result.stdout.fnmatch_lines(
         [


### PR DESCRIPTION
I ended up having to manually handle create `tmpdir` subdirectories in tests so that I could use `--iterations`, which is annoying, so seems better to have the framework do it.